### PR TITLE
Harden error handling across pipeline, backends, and reporting

### DIFF
--- a/src/veritail/reporting/comparison.py
+++ b/src/veritail/reporting/comparison.py
@@ -237,10 +237,17 @@ def _generate_terminal(
             if cjs:
                 appropriate = sum(1 for c in cjs if c.verdict == "appropriate")
                 inappropriate = sum(1 for c in cjs if c.verdict == "inappropriate")
-                console.print(
-                    f"  {label}: {len(cjs)} corrected "
-                    f"({appropriate} appropriate, {inappropriate} inappropriate)"
+                errored = sum(
+                    1 for c in cjs if c.verdict not in ("appropriate", "inappropriate")
                 )
+                line = (
+                    f"  {label}: {len(cjs)} corrected "
+                    f"({appropriate} appropriate, {inappropriate} inappropriate"
+                )
+                if errored:
+                    line += f", {errored} errored"
+                line += ")"
+                console.print(line)
 
     assert isinstance(console.file, StringIO)
     return console.file.getvalue()


### PR DESCRIPTION
## Summary

- **Pipeline resilience**: `backend.log_experiment()`, `backend.log_judgment()`, and `backend.log_correction_judgment()` calls are now wrapped in try/except - backend failures emit warnings but don't crash the evaluation. Judgments and corrections are still collected in-memory.
- **Comparison checks**: Wrapped per-query in try/except so a single query's comparison check failure doesn't lose both configs' worth of evaluation results.
- **File backend**: `get_judgments()` now skips corrupted JSONL lines (bad JSON, missing `product` key) with a `warnings.warn()` instead of crashing.
- **Langfuse backend**: `get_judgments()` now skips bad traces during retrieval with a warning instead of aborting the entire fetch.
- **Correction summaries**: Both pipeline console output and comparison reports now count and display error verdicts separately (e.g., "12 appropriate, 2 inappropriate, 1 errored") instead of silently dropping them from the tally.

## Test plan

- [x] `test_backend_log_judgment_failure_does_not_crash` - pipeline continues when `log_judgment` throws
- [x] `test_backend_log_experiment_failure_does_not_crash` - pipeline continues when `log_experiment` throws
- [x] `test_backend_log_correction_failure_does_not_crash` - corrections still collected when backend fails
- [x] `test_comparison_check_failure_does_not_crash` - dual evaluation completes despite comparison check errors
- [x] `test_correction_error_verdict_counted_in_summary` - error verdicts counted separately
- [x] `test_corrupted_jsonl_line_skipped` - bad JSON line skipped, valid lines still load
- [x] `test_missing_product_key_skipped` - missing `product` key handled gracefully
- [x] `test_get_judgments_skips_bad_trace` - Langfuse bad trace skipped, good traces still load
- [x] `test_correction_summary_shows_error_count` / `test_correction_summary_no_error_label_when_zero_errors` - comparison report error count display
- [x] All 333 tests pass, 3 skipped (langfuse optional). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)