### PR TITLE
Revamp automotive vertical with tiered severity structure

### DIFF
--- a/src/veritail/verticals/automotive.py
+++ b/src/veritail/verticals/automotive.py
@@ -101,9 +101,9 @@ identifiers as the primary fitment constraint for these queries.
 
 Query: "2019 Honda Civic front brake pads"
 Result: "Ceramic front brake pad set, fits 2016–2021 Honda Civic"
-→ SCORE: 3 (correct vehicle range, correct position, correct component)
+→ Highly relevant (correct vehicle range, correct position, correct component)
 
 Query: "2019 Honda Civic front brake pads"
 Result: "Front brake pad set for 2019 Honda Accord"
-→ SCORE: 0 (wrong vehicle model — Accord is not Civic; YMM mismatch \
+→ Irrelevant (wrong vehicle model — Accord is not Civic; YMM mismatch \
 is a hard disqualifier regardless of part similarity)"""


### PR DESCRIPTION
## Summary
- Restructured the automotive vertical prompt from 13 flat prose bullets (~3,300 tokens) into a three-tier severity system (~2,000 tokens): **hard gates** (immediate disqualifiers), **significant penalties** (major relevance penalty), and **soft signals** (tiebreaking only)
- Added 5 new domain-critical coverage areas: fluid/chemical specifications, dimensional specifications (tires, bolt patterns, thread pitch), universal vs direct-fit distinction, paint codes for collision parts, and engine-first heavy-duty search patterns
- Added calibration examples to anchor LLM scoring consistency
- Replaced numeric score prescriptions with qualitative severity language to avoid conflicts with the base `ecommerce_default` rubric's scoring scale

## Motivation
The previous automotive vertical was comprehensive but used flat prose that didn't clearly signal severity to the LLM judge. It also missed several domain-critical dimensions (fluids, dimensional specs, universal vs direct-fit, paint codes, heavy-duty patterns) and prescribed specific score numbers that could conflict with the base rubric.

## Changes
- Only `src/veritail/verticals/automotive.py` was modified
- No other files touched

## Test plan
- [x] All 412 tests pass (2 skipped — pre-existing), excluding pre-existing langfuse/pydantic v1 incompatibility on Python 3.14
- [x] `ruff check` and `ruff format` clean
- [x] `mypy src` clean
- [x] Verified vertical still contains `"Scoring considerations"` (test contract)
- [x] Verified no numeric score prescriptions conflict with base rubric

🤖 Generated with [Claude Code](https://claude.com/claude-code)