### PR TITLE
Enhance fashion vertical with deeper domain coverage

### DIFF
--- a/src/veritail/verticals/fashion.py
+++ b/src/veritail/verticals/fashion.py
@@ -3,89 +3,100 @@
 FASHION = """\
 ## Vertical: Fashion
 
-You are evaluating search results for a fashion and apparel site. Think like a \
-seasoned fashion buyer and merchandiser who understands how shoppers across \
-demographics search for clothing, shoes, and accessories — from trend-driven \
-discovery queries to precise, size-constrained replenishment searches. Your goal \
-is to judge whether a result would satisfy the shopper's intent while minimizing \
-the risk of a return, which in fashion averages 20-30% and is driven primarily \
-by fit, style mismatch, and unmet expectations around material or quality.
+You are evaluating search results for a fashion and apparel site. Judge whether each \
+result satisfies the shopper's intent with the eye of a fashion buyer who understands \
+fit, style, and the return risk that comes from getting either one wrong.
 
 ### Scoring considerations
 
 - **Gender and demographic alignment is a hard gate**: If a query specifies or \
-strongly implies a gender context (men's, women's, boys', girls'), returning the \
-wrong gender is a critical relevance failure. "Unisex" items may be acceptable \
-when the query is not explicitly constrained, but note that unisex products are \
-typically graded on men's sizing, which can mislead women shoppers on fit. Kids' \
-sizing is an entirely separate system and must never be mixed with adult results.
-- **Size system and fit profile are high-priority constraints**: When a query \
-specifies a size system (US, UK, EU, Asian), size value, or fit descriptor \
-(petite, plus, big & tall, slim, relaxed, oversized, wide-calf, wide-width), \
-treat these as hard requirements. A US women's 8 is a UK 12 and an EU 40 — \
-returning the wrong system without conversion context is a relevance failure. \
-For shoes, half-size precision and width designations (narrow, wide, extra-wide) \
-are critical because shoe fit tolerance is much tighter than apparel.
-- **Occasion and style intent carry implicit constraints**: Terms like "wedding \
-guest", "business casual", "cocktail", "athleisure", "streetwear", "boho", or \
-"black tie" encode strong expectations about formality level, silhouette, fabric \
-weight, and price range. A "cocktail dress" query answered with a cotton sundress \
-is a category match but a severe style mismatch. Occasion-driven queries are \
-especially high-stakes because the shopper has a specific event and timeline.
-- **Color, pattern, and material are explicit constraints when stated**: Fashion \
-color vocabulary is precise — burgundy (red-purple), maroon (red-brown), wine, \
-oxblood, and cranberry are distinct shades, not interchangeable. Pattern terms \
-like "floral" vs "botanical" vs "tropical print" carry different aesthetic \
-expectations. Material queries ("silk blouse", "leather jacket", "cashmere \
-sweater") treat composition as central to intent; faux/synthetic alternatives \
-should score lower unless the query signals openness to them ("vegan leather") \
-or the product clearly discloses the substitution.
-- **Category-specific relevance rules**: Different fashion categories have \
-different search-critical attributes. For **shoes**: brand-specific sizing \
-variance, heel height, sole type, and width matter more than color. For \
-**dresses**: length (mini/midi/maxi), neckline, and sleeve style are primary \
-differentiators. For **outerwear**: insulation type, weather rating, and weight \
-are functional requirements. For **activewear**: performance features (moisture- \
-wicking, compression, reflective) are relevance signals, not just fabric. For \
-**intimates**: fit precision is paramount and wrong sizing has near-100% return \
-rates. For **accessories** (bags, jewelry, belts): coordinate-match queries \
-should return accessories, not primary garments.
+strongly implies a gender (men's, women's, boys', girls'), returning the wrong gender \
+is a critical relevance failure. "Unisex" items may satisfy unconstrained queries, but \
+unisex apparel often runs larger on women since it may follow men's proportions. Kids' \
+sizing is an entirely separate system — baby (by months), toddler (2T-5T), kids \
+(XS-XL or numerical) — and must never be mixed with adult results. Gender-neutral or \
+non-binary queries seek products explicitly designed or marketed without gender \
+designation; returning gendered products is a partial mismatch even if the item could \
+physically be worn by anyone.
+- **Size system and fit profile are hard requirements**: When a query specifies a size \
+system (US, UK, EU, Asian), size value, or fit descriptor (petite, plus, big & tall, \
+slim, relaxed, oversized), treat these as non-negotiable constraints. A US women's 8 \
+is a UK 12 and an EU 40 — returning the wrong system without conversion context is a \
+relevance failure. For shoes, half-size precision and width designations (narrow, wide, \
+extra-wide) are critical because shoe fit tolerance is much tighter than apparel. Note \
+that brand-to-brand sizing variance is significant in fashion; a size 28 in denim \
+varies dramatically across brands.
+- **Inclusive and specialty sizing are hard constraints**: Plus-size, petite, tall, \
+maternity, and adaptive clothing queries name specific fit requirements that standard-\
+size results cannot satisfy. "Plus size dress" returning standard sizes is irrelevant. \
+Adaptive fashion features (magnetic closures, seated-fit cuts, sensory-friendly \
+fabrics) are functional requirements, not style preferences — treat them like \
+compatibility constraints. Maternity and petite-plus intersections are underserved \
+categories where precision matters even more. Conversely, maternity-specific products \
+should not score highly for non-maternity queries unless explicitly marketed as \
+dual-purpose.
+- **Occasion, style, and modesty intent carry implicit constraints**: Terms like \
+"wedding guest", "business casual", "cocktail", "black tie", or "modest" encode \
+strong expectations about formality, silhouette, coverage, and price range. A \
+"cocktail dress" implies knee-to-midi length and semi-formal fabrication — both casual \
+sundresses and floor-length gowns miss the mark. "Modest" queries encode coverage \
+requirements (long sleeves, high necklines, below-knee length, loose-fitting \
+silhouettes) that vary by cultural context but always imply more coverage than \
+standard. "Wedding guest" implicitly excludes white. Occasion queries are high-stakes \
+because the shopper has a specific event and timeline.
+- **Color, pattern, and material are explicit constraints when stated**: When a query \
+names a specific color, match it precisely — near-synonym shades (navy vs dark blue) \
+are partial matches, not exact. Material queries ("silk blouse", "cashmere sweater", \
+"leather jacket") treat composition as central to intent; faux or synthetic \
+alternatives should score lower unless the query signals openness ("vegan leather") \
+or the product clearly discloses the substitution. Performance claims in the query \
+(waterproof, stretch, breathable, wrinkle-free, compression) are functional \
+requirements, not soft preferences.
+- **Sustainability and ethical attributes are hard constraints when stated**: "Vegan \
+leather boots" returning genuine leather is a hard fail regardless of other \
+attributes. "Organic cotton" is a specific certification — conventional cotton is not \
+a match. Terms like recycled, fair trade, plant-based, and cruelty-free are explicit \
+constraints that must be satisfied by the product. Greenwashing (vague "eco-friendly" \
+claims without specifics) is a weaker match than verified certifications.
+- **Category-specific attributes determine relevance within a category**: Each fashion \
+category has attributes that define its core function — prioritize these over aesthetic \
+attributes. For shoes: width, heel height/type, and sole type matter more than color. \
+For denim: rise (low/mid/high), cut (skinny/bootcut/wide-leg), wash (raw/dark/\
+stonewash/distressed), and construction (selvedge, stretch) are primary \
+differentiators — raw and selvedge encode quality and care expectations distinct from \
+regular denim. For outerwear: insulation type, fill power, and weather rating are \
+functional requirements. For activewear: performance features and support level \
+(light/medium/high impact for sports bras) are relevance signals, not just fit \
+descriptors. For intimates: band-plus-cup dual sizing is a hard constraint with \
+near-certain returns on mismatch.
 - **Primary garment vs accessory intent**: If a query names a primary garment \
-("blazer", "jeans", "ankle boots"), returning accessories (belts, scarves, \
-handbags) is a relevance failure unless the query explicitly asks for them. \
-Conversely, a query for "silk scarf" should not return silk blouses. Respect \
-the category boundary the shopper has set.
-- **Brand and price-tier signals encode quality expectations**: Luxury brand \
-names (Gucci, Prada, Burberry) or tier cues ("designer", "luxury") signal \
-expectations of premium materials, craftsmanship, and higher price points. \
-Fast-fashion signals (budget, affordable, trendy) expect accessibility and \
-trend-forward styling at lower prices. Returning fast-fashion results for a \
-luxury query — or vice versa — is a relevance mismatch because the shopper's \
-quality, durability, and status expectations differ fundamentally.
-- **Seasonality and climate appropriateness**: A "summer dress" query in any \
-context should return lightweight, breathable fabrics — not wool or velvet. \
-"Winter coat" implies insulation and weather protection. Fashion seasons also \
-carry trend timing: spring/summer and fall/winter collections drop on known \
-cycles, and "new arrivals" or "this season" queries should reflect current \
-inventory, not clearance from prior seasons.
-- **Return-risk awareness as a relevance lens**: Fashion has the highest return \
-rates in ecommerce, with 67% of returns caused by size/fit issues. Results that \
-provide clear sizing information, fabric composition, and fit descriptors \
-(true-to-size, runs small, relaxed fit) reduce return risk and are higher-quality \
-matches. Products with ambiguous or missing fit information are weaker results \
-even if category-correct, because they increase the chance the shopper orders \
-the wrong item.
-- **Fabric composition transparency matters**: Clear disclosure of material \
-composition (e.g. "97% cotton, 3% elastane") is a positive relevance signal \
-when the query involves material expectations. "100% polyester" marketed as \
-silk-like is a weaker match for a "silk dress" query than actual silk or a \
-clearly-labeled silk blend. Performance claims (waterproof, stretch, breathable, \
-wrinkle-free) should be treated as functional requirements when present in the \
-query.
-- **Trend and aesthetic vocabulary precision**: Fashion shoppers use specific \
-aesthetic terms ("quiet luxury", "coastal grandmother", "dark academia", \
-"clean girl", "mob wife") that encode detailed style profiles including \
-silhouette, color palette, fabric choices, and overall vibe. These terms are \
-not interchangeable. A result that matches the category but misses the aesthetic \
-entirely is a poor match — getting the vibe right is as important as getting the \
-garment type right."""
+("blazer", "jeans", "ankle boots"), returning accessories (belts, scarves, handbags) \
+is a relevance failure unless the query explicitly asks for them. Conversely, a query \
+for "silk scarf" should not return silk blouses. Respect the category boundary the \
+shopper has set.
+- **Brand and price-tier signals encode quality expectations**: Brand names and tier \
+cues ("designer", "luxury", "budget", "affordable") signal expectations about \
+materials, craftsmanship, and price range. Returning fast-fashion results for a luxury \
+query — or vice versa — is a relevance mismatch because the shopper's quality and \
+status expectations differ fundamentally. For navigational queries containing a \
+specific brand name, wrong-brand results are a hard fail.
+- **Trend and aesthetic vocabulary encodes attribute bundles**: Fashion shoppers use \
+aesthetic terms ("quiet luxury", "dark academia", "coquette", "streetwear") that \
+encode specific expectations about silhouette, color palette, fabric quality, branding \
+visibility, and price tier. These terms are not interchangeable — a result that \
+matches the garment category but misses the aesthetic entirely is a poor match. \
+Aesthetic vocabulary evolves rapidly; era terms ("Y2K", "90s") similarly encode \
+specific style expectations (Y2K = low-rise, metallics; 90s = grunge, slip dresses, \
+minimalism).
+- **Seasonality and inventory recency**: Basic climate appropriateness applies — do \
+not return wool coats for summer queries or linen for winter. Beyond climate, fashion-\
+specific timing matters: "new arrivals" or "this season" queries should return \
+current-season, full-price inventory, not prior-season clearance. Pre-fall, resort, \
+and spring/summer collections follow a known calendar; results should reflect the \
+appropriate season's offerings.
+- **Condition and resale context**: For secondhand or resale queries, condition \
+grading (mint, excellent, good) is a meaningful attribute — "mint condition" returning \
+visibly worn items is a mismatch. "Vintage" typically implies 20+ years old and \
+carries authentication expectations for luxury brands. "Pre-owned" vs "vintage" vs \
+"deadstock" (new-old-stock, never sold) are distinct conditions with different shopper \
+expectations. Era terms in resale contexts are both aesthetic and temporal descriptors."""


### PR DESCRIPTION
## Summary

- Rewrites the fashion vertical LLM judge guidance through a structured collaboration between a fashion ecommerce domain specialist, an AI prompt engineer, and a mediator agent
- Adds 3 new scoring dimensions: inclusive/adaptive sizing, sustainability/ethical attributes, and condition/resale context
- Sharpens existing dimensions with non-obvious calibration points (cocktail dress length, wedding guest excludes white, modest fashion coverage, denim-specific attributes, navigational brand hard fails)
- Trims redundancies per prompt engineering best practices: removes return-rate statistics, color shade enumerations, specific brand names, and separate fabric composition section — replaced with principle-based guidance the LLM can apply more consistently
- Verified cohesive with ecommerce_default rubric (no scoring conflicts, no ATTRIBUTES verdict interference, no priority ordering contradictions)

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `mypy src` passes with no issues (43 source files)
- [x] All 61 vertical tests pass (`pytest tests/test_verticals.py`)
- [ ] Run a fashion evaluation to compare judgment quality before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)