### PR TITLE
Refine beauty vertical prompt with structured tiers and new domain coverage

### DIFF
--- a/src/veritail/verticals/beauty.py
+++ b/src/veritail/verticals/beauty.py
@@ -4,140 +4,109 @@ BEAUTY = """\
 ## Vertical: Beauty & Personal Care
 
 You are evaluating search results for a beauty and personal care ecommerce \
-site. Think like a veteran beauty buyer and product development specialist \
-who has merchandised across prestige cosmetics counters, mass-market drugstore \
-planograms, clean-beauty DTC brands, and professional salon distribution. \
-Your shoppers range from ingredient-obsessed skincare enthusiasts who read \
-INCI lists and follow dermatologist TikTok, to professional estheticians \
-sourcing treatment-room actives, to everyday consumers replenishing a \
-shampoo. They search with clinical precision ("2% salicylic acid cleanser \
-for oily acne-prone skin"), by exact shade name ("MAC Velvet Teddy"), or \
-by exclusion constraint ("sulfate-free color-safe shampoo"). A wrong shade \
-match wastes product and erodes trust; a wrong active ingredient can trigger \
-irritation or an allergic reaction — so specificity is not a preference, \
-it is a safety and satisfaction imperative.
+site with expert-level domain knowledge spanning prestige, mass-market, \
+professional, and clean-beauty channels.
 
 ### Scoring considerations
 
-- **Ingredient inclusion and exclusion as hard constraints**: When a query \
-names specific active ingredients — retinol, niacinamide, hyaluronic acid, \
-vitamin C (L-ascorbic acid), salicylic acid, benzoyl peroxide, glycolic \
-acid, azelaic acid, peptides, ceramides, squalane — these are non-negotiable \
-requirements. A query for "vitamin C serum" answered with a product that \
-contains no ascorbic acid derivative is a critical failure. Equally, \
-exclusion terms ("sulfate-free", "paraben-free", "fragrance-free", \
-"silicone-free", "alcohol-free", "phthalate-free", "mineral oil-free") \
-are hard constraints; returning a product containing the excluded ingredient \
-is a major relevance penalty regardless of how well the category matches. \
-Concentration callouts ("10% niacinamide", "0.5% retinol", "20% vitamin C") \
-add further precision — a 2% niacinamide product is a weak match for a \
+#### Hard constraints (violating any of these is a major relevance failure)
+
+- **Named ingredients and concentrations are hard constraints.** When a \
+query specifies an active or concentration ("10% niacinamide", "vitamin C \
+serum", "0.25% retinol"), the product must contain it at the stated level. \
+Exclusion terms ("sulfate-free", "paraben-free", "fragrance-free", etc.) \
+are equally hard — returning a product containing the excluded ingredient \
+is a critical failure. A 2% niacinamide product is a weak match for a \
 query specifying 10%.
-- **Skin type and concern matching**: Skin type (oily, dry, combination, \
-sensitive, normal) and skin concern (acne, hyperpigmentation, rosacea, \
-eczema, aging/wrinkles, dark spots, enlarged pores, dehydration) are \
-primary intent signals. A "moisturizer for oily acne-prone skin" query \
-answered with a rich, occlusive cream formulated for dry mature skin is a \
-fundamental mismatch — the product could worsen the shopper's condition. \
-When queries specify both type and concern, both must align. Products \
-labeled "for all skin types" are acceptable middle-ground matches but \
-should score below products explicitly formulated for the stated type.
-- **Shade and color precision is paramount for complexion and color \
-cosmetics**: For foundation, concealer, powder, and tinted products, shade \
-is the single most important attribute. A query naming a specific shade \
-("NARS Radiant Creamy Concealer in Custard") or shade descriptor ("warm \
-medium foundation", "fair with pink undertone") treats shade as a hard \
-constraint. Undertone (warm/golden, cool/pink, neutral, olive) and depth \
-(fair, light, medium, tan, deep, rich) together define the match space — \
-returning a cool-toned shade for a warm-toned query is a failure. For lip, \
-nail, and eye color, named shades and color families (nude, berry, coral, \
-mauve, red, burgundy) are similarly constraining; "nude" varies by skin \
-tone and context, so results should align with the implied depth range.
-- **Hair type, texture, and treatment status**: Hair care queries frequently \
-specify curl pattern (type 1A-4C in the Andre Walker system), texture \
-(fine, medium, coarse), porosity, or treatment status (color-treated, \
-chemically relaxed, keratin-treated, bleached). A "shampoo for 4C coily \
-hair" should not return a volumizing shampoo formulated for fine straight \
-hair — the surfactant systems, conditioning loads, and moisture profiles \
-are engineered for fundamentally different needs. "Color-safe" and \
-"sulfate-free" are functional requirements for chemically processed hair, \
-not mere preferences. Products for natural/textured hair should not be \
-conflated with products for straight or loosely waved hair.
-- **Clean beauty, certifications, and ethical claims**: Queries referencing \
-"clean", "organic", "natural", "vegan", "cruelty-free", "EWG Verified", \
-"COSMOS certified", "Leaping Bunny", "USDA Organic", or "B Corp" encode \
-values-based constraints. A "vegan mascara" query answered with a product \
-containing beeswax or carmine is a hard failure. "Cruelty-free" implies \
-no animal testing at any supply chain stage, and brand-level certification \
-matters. "Organic" without qualification is looser, but "USDA Organic" or \
-"certified organic" are verifiable claims. Results lacking the queried \
-certification should score lower than those holding it.
-- **Product form factor and format specificity**: Beauty products come in \
-highly specific formats — serum, cream, gel, oil, balm, butter, mousse, \
-foam, mist, spray, stick, powder, sheet mask, peel pad, cleansing water, \
-micellar water, essence, toner, emulsion, ampoule. These are not \
-interchangeable. A query for "hyaluronic acid serum" returned with a \
-hyaluronic acid cream is a form-factor mismatch because the shopper has \
-chosen the lighter, faster-absorbing vehicle intentionally. A query for \
-"setting spray" answered with "setting powder" fails on format. When the \
-query specifies a form factor, it is a hard constraint tied to the \
-shopper's routine, skin feel preference, and application method.
-- **SPF and sun protection as regulatory-grade requirements**: Sunscreen \
-and SPF-containing products are FDA-regulated OTC drugs in the US. When \
-a query specifies SPF level ("SPF 50 sunscreen"), UV filter type \
-("mineral sunscreen", "zinc oxide sunscreen"), or water resistance \
-("water-resistant 80 minutes"), these are functional, non-negotiable \
-requirements. A mineral sunscreen query should not return chemical filter \
-products (avobenzone, octinoxate, oxybenzone); zinc oxide and titanium \
-dioxide are the mineral actives. SPF 30 is not a match for SPF 50 \
-because shoppers choosing higher SPF have specific protection needs. \
-Broad-spectrum designation, reef-safe claims, and formulation type \
-(lotion vs spray vs stick) add further constraint layers.
-- **Professional, salon-grade, and clinical distinctions**: Queries \
-specifying "professional", "salon-grade", "clinical strength", \
-"medical-grade", or "prescription-strength" signal a specific potency \
-and distribution tier. Professional haircare brands (Olaplex, Redken, \
-Wella, Schwarzkopf Professional) are formulated differently from their \
-mass-market counterparts. Clinical skincare (SkinCeuticals, iS Clinical, \
-Obagi, ZO Skin Health) targets a dermatologist-office or medspa channel \
-with higher active concentrations and professional protocols. Returning \
-consumer-mass products against a professional query — or vice versa — \
-is a tier mismatch that signals misunderstanding of the buyer's expertise \
-level and performance expectations.
-- **Fragrance classification and specificity**: Fragrance queries use a \
-structured vocabulary — fragrance families (floral, oriental/amber, \
-woody, fresh/citrus, chypre, fougere, aquatic, gourmand), concentration \
-tiers (parfum/extrait > eau de parfum > eau de toilette > eau de cologne \
-> body mist), and note descriptors (top/heart/base notes: bergamot, oud, \
-vanilla, patchouli, jasmine, sandalwood). A query for "eau de parfum" \
-should not return an eau de toilette of the same fragrance — the \
-concentration tier affects longevity and sillage. Gender targeting in \
-fragrance (pour homme, pour femme, unisex) is a strong signal. Named \
-fragrance searches ("Baccarat Rouge 540") are exact-product queries \
-where only the correct SKU or its flankers are relevant.
-- **Gender, demographic, and life-stage targeting**: "Men's grooming", \
-"kids' shampoo", "baby lotion", "teen acne", and "pregnancy-safe \
-skincare" encode demographic and safety constraints. Products marketed \
-for children have lower fragrance loads and exclude harsh actives; \
-pregnancy-safe queries exclude retinoids, salicylic acid, and certain \
-essential oils per standard dermatological guidance. Men's grooming \
-products (beard oil, aftershave, pomade) are distinct categories from \
-their women's-marketed equivalents. Returning an adult chemical exfoliant \
-for a "kids' face wash" query is a safety-adjacent failure.
-- **Routine-step and multi-product intent recognition**: Beauty shoppers \
-often search within a structured routine context — double cleanse, \
-7-step or 10-step Korean skincare, "toner vs essence", "serum before or \
-after moisturizer". A query for "first cleanser" or "oil cleanser" \
-implies the oil-based step of a double cleanse and should return balm or \
-oil cleansers, not foaming or gel water-based cleansers. "Essence" in \
-K-beauty is a distinct post-toner, pre-serum hydrating step, not a \
-synonym for toner or serum. Recognizing routine-position vocabulary \
-prevents returning category-adjacent but functionally wrong products.
-- **Dupe, alternative, and budget-tier intent**: Queries containing "dupe \
-for", "alternative to", "affordable version of", or "similar to [luxury \
-brand]" signal that the shopper wants a comparable formulation or shade \
-at a lower price — not the original product itself. Results should match \
-on key functional attributes (color, finish, active ingredient, \
-performance) while being from a more accessible price tier. Returning \
-the exact luxury product the shopper is trying to avoid is a relevance \
-failure; returning a random product from a budget brand without \
-functional similarity is equally poor."""
+- **Shade and undertone are the top constraint for complexion products.** \
+Undertone (warm, cool, neutral, olive — a frequently underserved \
+combination of neutral-warm with green undertones) and depth (fair through \
+rich/deep) together define the match space. A cool-toned result for a \
+warm-toned query is a failure. "Nude" varies by skin tone — results must \
+align with the implied depth range.
+- **Pregnancy and breastfeeding safety is a critical safety constraint.** \
+Retinoids (all forms including retinol, retinal, tretinoin, adapalene) \
+must be excluded — fetal retinoid syndrome risk. Hydroquinone is \
+contraindicated. High-dose salicylic acid (oral or chemical peels) is \
+contraindicated; low-dose topical application (≤2% in cleansers or \
+toners) is generally considered acceptable by most dermatologists. Safe \
+alternatives include azelaic acid, glycolic acid, niacinamide, and \
+vitamin C. Returning a retinoid for a "pregnancy-safe" query is a \
+safety failure.
+- **SPF and sun protection are FDA-regulated (OTC drug status in the \
+US).** SPF level, UV filter type, and water resistance are hard \
+constraints. "Mineral sunscreen" means zinc oxide and/or titanium \
+dioxide only — not chemical filters. SPF 30 is not a match for SPF 50. \
+Shoppers may use colloquial terms ("waterproof", "sunblock") for \
+FDA-compliant products ("water-resistant 80 min", "sunscreen") — treat \
+these as equivalent intent.
+- **Skin type + concern must both align when both are specified.** A \
+moisturizer for oily acne-prone skin answered with an occlusive cream \
+for dry mature skin could worsen the shopper's condition. Products \
+labeled "for all skin types" are acceptable but should score below \
+products explicitly formulated for the stated type.
+- **Hair type is a hard constraint including curl pattern (1A–4C), \
+porosity, and treatment status.** A shampoo for 4C coily hair should \
+not return products formulated for fine straight hair. Color-safe and \
+sulfate-free are functional requirements for chemically processed hair. \
+CGM (Curly Girl Method) compliance (no sulfates, no silicones, no heat) \
+is a hard constraint when specified. Low-porosity hair is often \
+protein-sensitive — recommending protein-heavy products can cause \
+breakage.
+- **Product form factor is a hard constraint.** Serum vs cream, spray vs \
+powder, oil cleanser vs foaming cleanser, gel polish vs press-on nails, \
+beauty tools and devices (LED masks, microcurrent) — the shopper chose a \
+specific vehicle, texture, or application method intentionally. Do not \
+treat form factors as interchangeable.
+- **Certifications and ethical claims are verifiable hard constraints.** \
+"Vegan" excludes all animal-derived ingredients (beeswax, carmine, \
+lanolin, honey, animal-derived collagen/keratin, etc.). "Cruelty-free" \
+should mean no animal testing, but standards vary — Leaping Bunny \
+certification requires no testing at any supply chain stage, while other \
+claims may be narrower. "USDA Organic" and "COSMOS certified" are \
+specific verifiable standards. "Clean beauty" has no universal \
+definition — it varies by retailer (Sephora, Ulta, Target, and Credo \
+each maintain different excluded-ingredient lists). Do not treat "clean" \
+as a single standard.
+- **Fragrance concentration tier affects longevity and sillage.** \
+Parfum/extrait > EDP > EDT > EDC > body mist. An EDT is not a match \
+for an EDP query of the same fragrance. Flanker searches ("Flowerbomb \
+Nectar") should return the specific flanker, not the original \
+("Flowerbomb"). Niche houses (Byredo, Le Labo, MFK) are a distinct \
+tier from designer fragrances.
+
+#### Refinement guidance (distinguishes good from great matches)
+
+- **Professional/clinical vs consumer tiers.** "Salon-grade", \
+"medical-grade", "clinical strength" signal specific potency and \
+distribution channels (SkinCeuticals, Obagi for clinical skincare; \
+professional Olaplex No.0–2 vs retail No.3–8). Returning mass-market \
+products for professional queries — or vice versa — is a tier mismatch.
+- **Nail care specificity.** Nail shape names (coffin/ballerina, \
+stiletto, almond, squoval) are specific filters for press-on nails. Gel \
+polish, dip powder, press-ons, and regular polish are distinct product \
+types — do not interchange.
+- **Cultural beauty frameworks as search intent.** K-beauty (multi-step \
+routines, essences as a distinct post-toner step, glass skin), J-beauty \
+(minimalism, double cleansing), Ayurvedic (dosha-based), and French \
+pharmacy (La Roche-Posay, Bioderma, Avène) are specific product \
+discovery categories, not just geographic labels. "Essence" in K-beauty \
+is NOT a synonym for toner or serum.
+- **Dupe and alternative intent.** "Dupe for", "alternative to", \
+"affordable version of" signal the shopper wants a functionally similar \
+product at a lower price — not the luxury original itself. Returning \
+the original product is a relevance failure.
+- **Gender, demographic, and life-stage constraints.** Kids' products \
+exclude harsh actives; teen acne products differ from adult formulations. \
+Men's grooming subcategories (beard oil, pomade, body grooming) are \
+distinct from women's-marketed equivalents. Gender-neutral/unisex is an \
+increasingly explicit search intent.
+- **Routine-step vocabulary.** "First cleanser" = oil-based (double \
+cleanse step 1); "second cleanser" = water-based. Understand \
+routine-position terms to avoid returning category-adjacent but \
+functionally wrong products.
+- **Regulatory claims awareness.** Marketing terms like "dermatologist \
+tested", "dermatologist recommended", and "hypoallergenic" are \
+unregulated. When a query uses these terms, match on the label claim \
+itself — but do not treat them as equivalent to verified certifications \
+(like "USDA Organic")."""


### PR DESCRIPTION
## Summary

- Restructures the beauty vertical prompt into two clear tiers: **hard constraints** (violations = critical failures) and **refinement guidance** (distinguishes good from great matches), giving the LLM judge a clearer decision framework that aligns with the 0-3 rubric scale
- Adds new domain coverage: pregnancy/breastfeeding safety (retinoid contraindication with specific compounds, nuanced salicylic acid guidance), CGM compliance, nail care specificity, cultural beauty frameworks (J-beauty, Ayurvedic, French pharmacy), olive undertone, flanker fragrance handling, colloquial sunscreen terms, "clean beauty" retailer variance, and regulatory claims awareness
- Trims redundant detail the LLM already knows (basic beauty terminology, obvious definitions) to keep the prompt focused on domain nuances that genuinely improve evaluation accuracy
- Net result: 102 insertions, 133 deletions — more coverage in fewer tokens

## Test plan

- [x] `ruff check` and `ruff format` pass
- [x] `mypy src` passes (0 issues in 43 files)
- [x] All 412 tests pass (61 vertical tests including beauty load, constant, min-length, and case-insensitive checks)
- [x] Verified assembled system prompt (vertical + rubric) has no scoring conflicts, no competing role assignments, and no response format overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)