### PR TITLE
Add LLM-powered AI Summary to reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- LLM-powered AI Summary section in single-config and A/B comparison HTML reports and terminal output. After evaluation, one additional LLM call cross-references metrics, check failures, judgment scores, and query-type breakdowns to surface non-obvious patterns and actionable insights. Gracefully omits itself when nothing meaningful is found. Disable with `--no-summary`.
 - 95% BCa bootstrap confidence intervals on all aggregate IR metrics (NDCG@5, NDCG@10, MRR, MAP, P@5, P@10, Attribute Match@5/10). Displayed in both terminal and HTML reports. Uses 10,000 resamples with a fixed seed for reproducibility; zero extra LLM calls.
 - Paired bootstrap significance test for A/B comparison mode. Statistically significant metric differences (p < 0.05) are marked with `*` in the metrics comparison table, with exact p-values available on hover in HTML reports.
 - HTML report UI redesign: shared CSS design system with design tokens, dark mode support (`prefers-color-scheme`), KPI hero cards with color-coded quality tiers (good/fair/poor/bad), sticky navigation bar with scrollspy, score badges, severity badges, modern light table headers replacing dark navy, and a print stylesheet. Applies to all report types (single, comparison, autocomplete, autocomplete comparison).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Summary now renders `**bold**` markdown as proper `<strong>` tags in HTML reports instead of showing raw asterisks.
 - AI Summary card in single-config HTML reports now appears after the KPI cards instead of before them.
 - AI Summary no longer shows truncated mid-sentence bullets. If the LLM runs out of tokens, the incomplete final bullet is silently dropped.
+- Fixed CSS unicode escapes (bullet markers, Show more arrows) being mangled by Python string interpretation in the shared stylesheet.
+- Fixed "Show more" collapsible breaking when the LLM separates bullets with blank lines — overflow bullets now stay collapsed regardless of whitespace.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Paired bootstrap significance test now uses null-centered (shifted) methodology (Sakai 2006/2007) instead of resampling from observed deltas, which was anti-conservative on small query sets.
 - Non-significant p-values in HTML comparison reports are now visible as text (e.g. `p=0.23`) instead of rendering as an invisible empty element.
+- Clicking a query in the "Worst Performing Queries" table now correctly opens and scrolls to its judgment details. Previously, the click handler was not registered when the report had 10 or fewer queries.
 
 ## [0.3.1] - 2026-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - LLM-powered AI Summary section in single-config and A/B comparison HTML reports and terminal output. After evaluation, one additional LLM call cross-references metrics, check failures, judgment scores, and query-type breakdowns to surface non-obvious patterns and actionable insights. Gracefully omits itself when nothing meaningful is found. Disable with `--no-summary`.
+- Comparison summary now includes result overlap (Jaccard), position shifts, per-config score distributions, and statistical significance (p-values) so the LLM can ground insights in concrete evidence.
+
+### Changed
+
+- Renamed "High-Variance Queries" section to "Mixed-Relevance Queries (widest score spread)" in single-report summary payloads to avoid misleading the LLM about expected relevance decay.
+
+### Fixed
+
+- `generate_summary()` and `generate_comparison_summary()` now catch exceptions internally and return `None`, matching their documented error contract instead of propagating to the CLI.
+- Worst-query payload lookups now correctly resolve disambiguated keys (e.g. `"shoes [1]"`) back to raw query data, fixing silent data loss for duplicate queries.
 - 95% BCa bootstrap confidence intervals on all aggregate IR metrics (NDCG@5, NDCG@10, MRR, MAP, P@5, P@10, Attribute Match@5/10). Displayed in both terminal and HTML reports. Uses 10,000 resamples with a fixed seed for reproducibility; zero extra LLM calls.
 - Paired bootstrap significance test for A/B comparison mode. Statistically significant metric differences (p < 0.05) are marked with `*` in the metrics comparison table, with exact p-values available on hover in HTML reports.
 - HTML report UI redesign: shared CSS design system with design tokens, dark mode support (`prefers-color-scheme`), KPI hero cards with color-coded quality tiers (good/fair/poor/bad), sticky navigation bar with scrollspy, score badges, severity badges, modern light table headers replacing dark navy, and a print stylesheet. Applies to all report types (single, comparison, autocomplete, autocomplete comparison).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Worst-query payload lookups now correctly resolve disambiguated keys (e.g. `"shoes [1]"`) back to raw query data, fixing silent data loss for duplicate queries.
 - AI Summary now renders `**bold**` markdown as proper `<strong>` tags in HTML reports instead of showing raw asterisks.
 - AI Summary card in single-config HTML reports now appears after the KPI cards instead of before them.
+- AI Summary no longer shows truncated mid-sentence bullets. If the LLM runs out of tokens, the incomplete final bullet is silently dropped.
+
+### Changed
+
+- AI Summary token limit increased from 512 to 1024 so the LLM can complete all 5 bullets without truncation.
+- AI Summary bullets beyond the first 3 are now collapsed behind a "Show more" toggle to keep the card compact.
 - 95% BCa bootstrap confidence intervals on all aggregate IR metrics (NDCG@5, NDCG@10, MRR, MAP, P@5, P@10, Attribute Match@5/10). Displayed in both terminal and HTML reports. Uses 10,000 resamples with a fixed seed for reproducibility; zero extra LLM calls.
 - Paired bootstrap significance test for A/B comparison mode. Statistically significant metric differences (p < 0.05) are marked with `*` in the metrics comparison table, with exact p-values available on hover in HTML reports.
 - HTML report UI redesign: shared CSS design system with design tokens, dark mode support (`prefers-color-scheme`), KPI hero cards with color-coded quality tiers (good/fair/poor/bad), sticky navigation bar with scrollspy, score badges, severity badges, modern light table headers replacing dark navy, and a print stylesheet. Applies to all report types (single, comparison, autocomplete, autocomplete comparison).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `generate_summary()` and `generate_comparison_summary()` now catch exceptions internally and return `None`, matching their documented error contract instead of propagating to the CLI.
 - Worst-query payload lookups now correctly resolve disambiguated keys (e.g. `"shoes [1]"`) back to raw query data, fixing silent data loss for duplicate queries.
+- AI Summary now renders `**bold**` markdown as proper `<strong>` tags in HTML reports instead of showing raw asterisks.
+- AI Summary card in single-config HTML reports now appears after the KPI cards instead of before them.
 - 95% BCa bootstrap confidence intervals on all aggregate IR metrics (NDCG@5, NDCG@10, MRR, MAP, P@5, P@10, Attribute Match@5/10). Displayed in both terminal and HTML reports. Uses 10,000 resamples with a fixed seed for reproducibility; zero extra LLM calls.
 - Paired bootstrap significance test for A/B comparison mode. Statistically significant metric differences (p < 0.05) are marked with `*` in the metrics comparison table, with exact p-values available on hover in HTML reports.
 - HTML report UI redesign: shared CSS design system with design tokens, dark mode support (`prefers-color-scheme`), KPI hero cards with color-coded quality tiers (good/fair/poor/bad), sticky navigation bar with scrollspy, score badges, severity badges, modern light table headers replacing dark navy, and a print stylesheet. Applies to all report types (single, comparison, autocomplete, autocomplete comparison).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AI Summary no longer shows truncated mid-sentence bullets. If the LLM runs out of tokens, the incomplete final bullet is silently dropped.
 - Fixed CSS unicode escapes (bullet markers, Show more arrows) being mangled by Python string interpretation in the shared stylesheet.
 - Fixed "Show more" collapsible breaking when the LLM separates bullets with blank lines — overflow bullets now stay collapsed regardless of whitespace.
+- "Show more" toggle in AI Summary now appears at the bottom of the expanded content (instead of staying at the top) and changes to "Show less" when expanded.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Renamed "High-Variance Queries" section to "Mixed-Relevance Queries (widest score spread)" in single-report summary payloads to avoid misleading the LLM about expected relevance decay.
+- The `text_overlap` check is now excluded from the AI Summary payload. It is redundant with the LLM judge's relevance scores (which feed into NDCG) and added noise without diagnostic value.
 
 ### Fixed
 
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed CSS unicode escapes (bullet markers, Show more arrows) being mangled by Python string interpretation in the shared stylesheet.
 - Fixed "Show more" collapsible breaking when the LLM separates bullets with blank lines — overflow bullets now stay collapsed regardless of whitespace.
 - "Show more" toggle in AI Summary now appears at the bottom of the expanded content (instead of staying at the top) and changes to "Show less" when expanded.
+- Detection-only checks (e.g. `near_duplicate`) that never emit pass results are now reported as "N findings" in the summary payload instead of "0 passed, N failed (100% fail rate)", preventing the LLM from incorrectly concluding that every result fails the check.
 
 ### Changed
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -29,6 +29,7 @@ Run a single or dual-configuration evaluation.
 | `--sample` | *(none)* | Randomly sample N queries/prefixes for a faster evaluation (deterministic seed) |
 | `--batch` | off | Use provider batch API for LLM calls (50% cheaper, slower). Works with both search and autocomplete evaluation. Supported for OpenAI, Anthropic, and Gemini. Not compatible with `--llm-base-url` |
 | `--resume` | off | Resume a previously interrupted run. Requires `--config-name` to identify the previous run. In non-batch mode, skips queries already judged in `judgments.jsonl`. In batch mode, resumes polling for an in-flight batch from a saved checkpoint. `--llm-model` and `--top-k` must match the original run |
+| `--no-summary` | off | Disable the AI Summary section in reports. By default, one additional LLM call is made after evaluation to generate 3-5 non-obvious insights by cross-referencing metrics, checks, and judgments. Use this flag to skip that call |
 
 If `--config-name` is provided, pass one name per adapter.
 

--- a/src/veritail/prompts/reporting/comparison_summary.md
+++ b/src/veritail/prompts/reporting/comparison_summary.md
@@ -1,0 +1,24 @@
+You are a search quality analyst comparing two search configurations (A vs B) using evaluation data from an ecommerce search engine.
+
+Your task is to identify 3-5 **non-obvious, actionable insights** about what changed between the two configurations and why it matters. Cross-reference metric deltas, query-type breakdowns, check failures, and concrete query examples.
+
+## What makes a good insight
+
+- Explains WHERE the improvement or regression comes from (e.g., "Config B's NDCG gain is driven entirely by broad queries; navigational queries regressed")
+- Identifies trade-offs (e.g., "Config B fixes price outliers but introduces more low-overlap results")
+- Highlights query-type-specific effects (e.g., "Long-tail queries improved by 15% but attribute queries dropped 8%")
+- Flags whether regressions are concerning or acceptable given the overall gains
+- Suggests what to investigate next
+
+## What to avoid
+
+- Do NOT restate metric values or deltas (the user can already see them in the report)
+- Do NOT give generic advice like "consider A/B testing further"
+- Do NOT draw conclusions beyond what the data supports
+- Do NOT mention the data format or how you received the data
+
+## Output format
+
+Return a markdown bullet list (each line starts with `- `). Each bullet should be 1-2 sentences.
+
+If you cannot find any meaningful, non-obvious insights, return exactly: `__NO_INSIGHTS__`

--- a/src/veritail/prompts/reporting/comparison_summary.md
+++ b/src/veritail/prompts/reporting/comparison_summary.md
@@ -1,6 +1,6 @@
 You are a search quality analyst comparing two search configurations (A vs B) using evaluation data from an ecommerce search engine.
 
-Your task is to identify 3-5 **non-obvious, actionable insights** about what changed between the two configurations and why it matters. Cross-reference metric deltas, query-type breakdowns, check failures, and concrete query examples.
+Your task is to identify 3-5 **non-obvious, actionable insights** about what changed between the two configurations and why it matters. Cross-reference metric deltas, significance levels, query-type breakdowns, check failures, result overlap, position shifts, score distributions, and concrete query examples. Each bullet must reference at least two evidence sources from the data. If insufficient evidence, return `__NO_INSIGHTS__`.
 
 ## What makes a good insight
 

--- a/src/veritail/prompts/reporting/comparison_summary.md
+++ b/src/veritail/prompts/reporting/comparison_summary.md
@@ -1,6 +1,6 @@
-You are a search quality analyst comparing two search configurations (A vs B) using evaluation data from an ecommerce search engine.
+You are a search quality analyst summarizing what an A/B evaluation report reveals about how two search configurations compare.
 
-Your task is to identify 3-5 **non-obvious, actionable insights** about what changed between the two configurations and why it matters. Cross-reference metric deltas, significance levels, query-type breakdowns, check failures, result overlap, position shifts, score distributions, and concrete query examples. Each bullet must reference at least two evidence sources from the data. If insufficient evidence, return `__NO_INSIGHTS__`.
+Your task is to identify 3-5 **non-obvious, actionable insights** about what changed in **search engine behavior** between the two configurations and why it matters. Cross-reference metric deltas, significance levels, query-type breakdowns, check failures, result overlap, position shifts, score distributions, and concrete query examples. Each bullet must reference at least two evidence sources from the data. If insufficient evidence, return `__NO_INSIGHTS__`.
 
 ## What makes a good insight
 
@@ -16,6 +16,7 @@ Your task is to identify 3-5 **non-obvious, actionable insights** about what cha
 - Do NOT give generic advice like "consider A/B testing further"
 - Do NOT draw conclusions beyond what the data supports
 - Do NOT mention the data format or how you received the data
+- Do NOT comment on the evaluation methodology or tool configuration — focus on what the data says about the search engine
 
 ## Output format
 

--- a/src/veritail/prompts/reporting/summary.md
+++ b/src/veritail/prompts/reporting/summary.md
@@ -1,11 +1,11 @@
-You are a search quality analyst reviewing evaluation data from an ecommerce search engine.
+You are a search quality analyst summarizing what an evaluation report reveals about an ecommerce search engine's performance.
 
-Your task is to identify 3-5 **non-obvious, actionable insights** by cross-referencing the data layers below. Look for patterns that a human scanning individual tables would likely miss.
+Your task is to identify 3-5 **non-obvious, actionable insights** about the **search engine** by cross-referencing the data layers below. Look for patterns that a human scanning individual tables would likely miss.
 
 ## What makes a good insight
 
 - Connects two or more data points (e.g., a specific query type performs poorly AND has high check failure rates)
-- Identifies a systemic issue (e.g., relevance drops sharply after position 3, suggesting a ranking cutoff problem)
+- Identifies a systemic issue in the search engine (e.g., relevance drops sharply after position 3, suggesting a ranking cutoff problem)
 - Highlights an unexpected finding (e.g., navigational queries underperform broad queries, which is unusual)
 - Suggests a concrete next step (e.g., "investigate price outliers on long-tail queries — 4 of 5 worst queries have price_outlier failures")
 
@@ -15,6 +15,7 @@ Your task is to identify 3-5 **non-obvious, actionable insights** by cross-refer
 - Do NOT give generic advice like "improve relevance" or "consider tuning your search"
 - Do NOT draw conclusions beyond what the data supports
 - Do NOT mention the data format or how you received the data
+- Do NOT comment on the evaluation methodology or tool configuration — focus on what the data says about the search engine
 
 ## Output format
 

--- a/src/veritail/prompts/reporting/summary.md
+++ b/src/veritail/prompts/reporting/summary.md
@@ -1,0 +1,23 @@
+You are a search quality analyst reviewing evaluation data from an ecommerce search engine.
+
+Your task is to identify 3-5 **non-obvious, actionable insights** by cross-referencing the data layers below. Look for patterns that a human scanning individual tables would likely miss.
+
+## What makes a good insight
+
+- Connects two or more data points (e.g., a specific query type performs poorly AND has high check failure rates)
+- Identifies a systemic issue (e.g., relevance drops sharply after position 3, suggesting a ranking cutoff problem)
+- Highlights an unexpected finding (e.g., navigational queries underperform broad queries, which is unusual)
+- Suggests a concrete next step (e.g., "investigate price outliers on long-tail queries — 4 of 5 worst queries have price_outlier failures")
+
+## What to avoid
+
+- Do NOT restate metric values (the user can already see them in the report)
+- Do NOT give generic advice like "improve relevance" or "consider tuning your search"
+- Do NOT draw conclusions beyond what the data supports
+- Do NOT mention the data format or how you received the data
+
+## Output format
+
+Return a markdown bullet list (each line starts with `- `). Each bullet should be 1-2 sentences.
+
+If you cannot find any meaningful, non-obvious insights, return exactly: `__NO_INSIGHTS__`

--- a/src/veritail/reporting/comparison.py
+++ b/src/veritail/reporting/comparison.py
@@ -22,6 +22,7 @@ from veritail.reporting.single import (
     summarize_checks,
 )
 from veritail.reporting.styles import SHARED_CSS
+from veritail.reporting.summary import summary_bullets_to_html
 from veritail.types import CheckResult, CorrectionJudgment, JudgmentRecord, MetricResult
 
 _JINJA_ENV = Environment(
@@ -44,6 +45,7 @@ def generate_comparison_report(
     judgments_b: list[JudgmentRecord] | None = None,
     checks_a: list[CheckResult] | None = None,
     checks_b: list[CheckResult] | None = None,
+    summary: str | None = None,
 ) -> str:
     """Generate a comparison report for two evaluation configurations.
 
@@ -95,6 +97,7 @@ def generate_comparison_report(
             checks_b=checks_b,
             correction_judgments_a=correction_judgments_a,
             correction_judgments_b=correction_judgments_b,
+            summary=summary,
         )
     return _generate_terminal(
         metrics_a,
@@ -105,6 +108,7 @@ def generate_comparison_report(
         sig_results=sig_results,
         correction_judgments_a=correction_judgments_a,
         correction_judgments_b=correction_judgments_b,
+        summary=summary,
     )
 
 
@@ -117,13 +121,28 @@ def _generate_terminal(
     sig_results: dict[str, PairedBootstrapResult | None] | None = None,
     correction_judgments_a: list[CorrectionJudgment] | None = None,
     correction_judgments_b: list[CorrectionJudgment] | None = None,
+    summary: str | None = None,
 ) -> str:
     """Generate a rich-formatted terminal comparison report."""
+    from rich.markdown import Markdown
+    from rich.panel import Panel
+
     console = Console(file=StringIO(), width=120)
 
     console.print(
         f"\n[bold]Search Evaluation Comparison: '{config_a}' vs '{config_b}'[/bold]\n"
     )
+
+    if summary:
+        console.print(
+            Panel(
+                Markdown(summary),
+                title="[bold]AI Summary[/bold]",
+                border_style="blue",
+                padding=(1, 2),
+            )
+        )
+        console.print()
 
     # Side-by-side metrics
     table = Table(title="Metrics Comparison", show_header=True)
@@ -325,6 +344,7 @@ def _generate_html(
     checks_b: list[CheckResult] | None = None,
     correction_judgments_a: list[CorrectionJudgment] | None = None,
     correction_judgments_b: list[CorrectionJudgment] | None = None,
+    summary: str | None = None,
 ) -> str:
     """Generate an HTML comparison report."""
     tmpl_dir = Path(__file__).parent / "templates"
@@ -825,4 +845,5 @@ def _generate_html(
         winners=winners,
         losers=losers,
         shared_css=SHARED_CSS,
+        summary=summary_bullets_to_html(summary) if summary else None,
     )

--- a/src/veritail/reporting/styles.py
+++ b/src/veritail/reporting/styles.py
@@ -581,6 +581,29 @@ details[open] > summary .check-arrow { transform: rotate(90deg); }
   margin-bottom: var(--sp-2);
 }
 
+.summary-more {
+  margin-top: var(--sp-1);
+}
+
+.summary-toggle {
+  cursor: pointer;
+  color: var(--accent);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  list-style: none;
+  padding: var(--sp-1) 0;
+}
+
+.summary-toggle::-webkit-details-marker { display: none; }
+
+.summary-toggle::before {
+  content: "\25B8\00a0";
+}
+
+details[open] > .summary-toggle::before {
+  content: "\25BE\00a0";
+}
+
 /* ── Banner Link ──────────────────────────────────────────────── */
 .banner-link {
   background: var(--accent-bg);

--- a/src/veritail/reporting/styles.py
+++ b/src/veritail/reporting/styles.py
@@ -529,6 +529,58 @@ details summary::-webkit-details-marker { display: none; }
 details summary::marker { display: none; content: ""; }
 details[open] > summary .check-arrow { transform: rotate(90deg); }
 
+/* ── Summary Card ────────────────────────────────────────────── */
+.summary-card {
+  background: var(--bg-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--sp-5) var(--sp-6);
+  margin-bottom: var(--sp-6);
+  box-shadow: var(--shadow-md);
+  border-left: 4px solid var(--accent);
+}
+
+.summary-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  background: var(--accent-bg);
+  color: var(--accent);
+}
+
+.summary-content {
+  font-size: var(--text-base);
+  line-height: 1.7;
+  color: var(--text-primary);
+}
+
+.summary-content ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.summary-content li {
+  position: relative;
+  padding-left: 20px;
+  margin-bottom: var(--sp-2);
+}
+
+.summary-content li::before {
+  content: "\2022";
+  position: absolute;
+  left: 4px;
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.summary-content p {
+  margin-bottom: var(--sp-2);
+}
+
 /* ── Banner Link ──────────────────────────────────────────────── */
 .banner-link {
   background: var(--accent-bg);

--- a/src/veritail/reporting/styles.py
+++ b/src/veritail/reporting/styles.py
@@ -570,7 +570,7 @@ details[open] > summary .check-arrow { transform: rotate(90deg); }
 }
 
 .summary-content li::before {
-  content: "\2022";
+  content: "\\2022";
   position: absolute;
   left: 4px;
   color: var(--accent);
@@ -597,11 +597,11 @@ details[open] > summary .check-arrow { transform: rotate(90deg); }
 .summary-toggle::-webkit-details-marker { display: none; }
 
 .summary-toggle::before {
-  content: "\25B8\00a0";
+  content: "\\25B8\\00a0";
 }
 
 details[open] > .summary-toggle::before {
-  content: "\25BE\00a0";
+  content: "\\25BE\\00a0";
 }
 
 /* ── Banner Link ──────────────────────────────────────────────── */

--- a/src/veritail/reporting/styles.py
+++ b/src/veritail/reporting/styles.py
@@ -581,27 +581,15 @@ details[open] > summary .check-arrow { transform: rotate(90deg); }
   margin-bottom: var(--sp-2);
 }
 
-.summary-more {
-  margin-top: var(--sp-1);
-}
-
 .summary-toggle {
+  background: none;
+  border: none;
   cursor: pointer;
   color: var(--accent);
   font-size: var(--text-sm);
   font-weight: 500;
-  list-style: none;
   padding: var(--sp-1) 0;
-}
-
-.summary-toggle::-webkit-details-marker { display: none; }
-
-.summary-toggle::before {
-  content: "\\25B8\\00a0";
-}
-
-details[open] > .summary-toggle::before {
-  content: "\\25BE\\00a0";
+  font-family: inherit;
 }
 
 /* ── Banner Link ──────────────────────────────────────────────── */

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -420,7 +420,13 @@ def generate_summary(
         return None
 
     system_prompt = load_prompt("reporting/summary.md")
-    response = client.complete(system_prompt, payload, max_tokens=_SUMMARY_MAX_TOKENS)
+    try:
+        response = client.complete(
+            system_prompt, payload, max_tokens=_SUMMARY_MAX_TOKENS
+        )
+    except Exception:
+        logger.warning("summary LLM call failed", exc_info=True)
+        return None
     logger.debug(
         "summary llm call: tokens=%d+%d",
         response.input_tokens,
@@ -465,7 +471,13 @@ def generate_comparison_summary(
         return None
 
     system_prompt = load_prompt("reporting/comparison_summary.md")
-    response = client.complete(system_prompt, payload, max_tokens=_SUMMARY_MAX_TOKENS)
+    try:
+        response = client.complete(
+            system_prompt, payload, max_tokens=_SUMMARY_MAX_TOKENS
+        )
+    except Exception:
+        logger.warning("comparison summary LLM call failed", exc_info=True)
+        return None
     logger.debug(
         "comparison summary llm call: tokens=%d+%d",
         response.input_tokens,

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -494,9 +494,7 @@ def summary_bullets_to_html(text: str) -> str:
             if in_list:
                 parts.append("</ul>")
                 in_list = False
-            if in_details:
-                parts.append("</details>")
-                in_details = False
+            # Never close <details> on blank lines — only at the end
             continue
 
         if stripped.startswith("- "):

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -140,7 +140,7 @@ def _build_single_payload(
         variance_items.sort(key=lambda x: -x[1])
         top_var = variance_items[:3]
         if top_var and top_var[0][1] > 0:
-            lines = ["## High-Variance Queries (most inconsistent scores)"]
+            lines = ["## Mixed-Relevance Queries (widest score spread)"]
             for q_var, var in top_var:
                 sorted_scores = sorted(query_score_lists[q_var])
                 lines.append(f'- "{q_var}": variance={var:.2f}, scores={sorted_scores}')

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -1,0 +1,474 @@
+"""LLM-powered report summary generation."""
+
+from __future__ import annotations
+
+import html
+import logging
+import statistics
+from collections import defaultdict
+from collections.abc import Mapping
+
+from veritail.llm.client import LLMClient
+from veritail.prompts import load_prompt
+from veritail.types import (
+    CheckResult,
+    CorrectionJudgment,
+    JudgmentRecord,
+    MetricResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUMMARY_MAX_TOKENS = 512
+_NO_INSIGHTS_SENTINEL = "__NO_INSIGHTS__"
+_MIN_SUMMARY_LENGTH = 20
+
+
+def _truncate(text: str, max_len: int) -> str:
+    """Truncate *text* to *max_len* characters, appending '...' if cut."""
+    if len(text) <= max_len:
+        return text
+    return text[: max_len - 3] + "..."
+
+
+# ── Single report payload ────────────────────────────────────────
+
+
+def _build_single_payload(
+    metrics: list[MetricResult],
+    checks: list[CheckResult],
+    judgments: list[JudgmentRecord] | None,
+    correction_judgments: list[CorrectionJudgment] | None,
+    run_metadata: Mapping[str, object] | None,
+) -> str:
+    """Build a structured text payload for the single-report summary LLM call."""
+    sections: list[str] = []
+
+    # 1. Score distribution
+    if judgments:
+        score_counts: dict[int, int] = {0: 0, 1: 0, 2: 0, 3: 0}
+        for j in judgments:
+            score_counts[j.score] = score_counts.get(j.score, 0) + 1
+        total = sum(score_counts.values())
+        if total > 0:
+            lines = [f"## Score Distribution ({total} judgments)"]
+            for s in (3, 2, 1, 0):
+                pct = score_counts[s] / total * 100
+                lines.append(f"- Score {s}: {score_counts[s]} ({pct:.1f}%)")
+            sections.append("\n".join(lines))
+
+    # 2. Metrics + by-query-type
+    if metrics:
+        lines = ["## Metrics"]
+        for m in metrics:
+            ci_str = ""
+            if m.ci_lower is not None and m.ci_upper is not None:
+                ci_str = f" [CI: {m.ci_lower:.4f}-{m.ci_upper:.4f}]"
+            if m.query_count is not None and m.query_count == 0:
+                lines.append(f"- {m.metric_name}: N/A (no applicable queries)")
+            else:
+                lines.append(f"- {m.metric_name}: {m.value:.4f}{ci_str}")
+            if m.by_query_type:
+                for qt, val in sorted(m.by_query_type.items()):
+                    lines.append(f"  - {qt}: {val:.4f}")
+        sections.append("\n".join(lines))
+
+    # 3. Check summary (pass/fail counts)
+    if checks:
+        check_counts: dict[str, dict[str, int]] = {}
+        for c in checks:
+            if c.check_name not in check_counts:
+                check_counts[c.check_name] = {"passed": 0, "failed": 0}
+            key = "passed" if c.passed else "failed"
+            check_counts[c.check_name][key] += 1
+        lines = ["## Check Summary"]
+        for name, counts in sorted(check_counts.items()):
+            total_c = counts["passed"] + counts["failed"]
+            fail_rate = counts["failed"] / total_c * 100 if total_c > 0 else 0
+            lines.append(
+                f"- {name}: {counts['passed']} passed, "
+                f"{counts['failed']} failed ({fail_rate:.0f}% fail rate)"
+            )
+        sections.append("\n".join(lines))
+
+    # 4. Worst 5 queries (by NDCG@10)
+    ndcg = next((m for m in metrics if m.metric_name == "ndcg@10"), None)
+    if ndcg and ndcg.per_query and judgments:
+        # Build lookup structures
+        query_type_lookup: dict[str, str] = {}
+        query_scores: dict[str, list[tuple[int, int]]] = defaultdict(list)
+        query_reasoning: dict[str, str] = {}
+        for j in judgments:
+            if j.query_type and j.query not in query_type_lookup:
+                query_type_lookup[j.query] = j.query_type
+            query_scores[j.query].append((j.product.position, j.score))
+            if j.query not in query_reasoning:
+                query_reasoning[j.query] = j.reasoning
+
+        per_query_failed: dict[str, list[str]] = defaultdict(list)
+        for c in checks:
+            if not c.passed and c.check_name not in per_query_failed[c.query]:
+                per_query_failed[c.query].append(c.check_name)
+
+        sorted_queries = sorted(ndcg.per_query.items(), key=lambda x: x[1])[:5]
+        lines = ["## Worst 5 Queries (by NDCG@10)"]
+        for q, val in sorted_queries:
+            qt = query_type_lookup.get(q, "unknown")
+            scores = sorted(query_scores.get(q, []))
+            score_str = ", ".join(f"pos{p + 1}={s}" for p, s in scores)
+            failed = per_query_failed.get(q, [])
+            reason = _truncate(query_reasoning.get(q, ""), 120)
+            lines.append(f'- "{q}" (type={qt}, NDCG@10={val:.4f})')
+            if score_str:
+                lines.append(f"  Scores: [{score_str}]")
+            if failed:
+                lines.append(f"  Failed checks: {', '.join(failed)}")
+            if reason:
+                lines.append(f"  Sample reasoning: {reason}")
+        sections.append("\n".join(lines))
+
+    # 5. High-variance queries
+    if ndcg and ndcg.per_query and judgments and len(ndcg.per_query) >= 3:
+        query_score_lists: dict[str, list[int]] = defaultdict(list)
+        for j in judgments:
+            query_score_lists[j.query].append(j.score)
+
+        variance_items: list[tuple[str, float]] = []
+        for q_var, q_scores in query_score_lists.items():
+            if len(q_scores) >= 2:
+                variance_items.append((q_var, statistics.variance(q_scores)))
+        variance_items.sort(key=lambda x: -x[1])
+        top_var = variance_items[:3]
+        if top_var and top_var[0][1] > 0:
+            lines = ["## High-Variance Queries (most inconsistent scores)"]
+            for q_var, var in top_var:
+                sorted_scores = sorted(query_score_lists[q_var])
+                lines.append(f'- "{q_var}": variance={var:.2f}, scores={sorted_scores}')
+            sections.append("\n".join(lines))
+
+    # 6. Position decay
+    if judgments:
+        pos_scores: dict[int, list[int]] = defaultdict(list)
+        for j in judgments:
+            pos_scores[j.product.position + 1].append(j.score)
+        if len(pos_scores) >= 2:
+            lines = ["## Average Score by Position"]
+            for pos in sorted(pos_scores.keys()):
+                avg = sum(pos_scores[pos]) / len(pos_scores[pos])
+                lines.append(f"- Position {pos}: {avg:.2f}")
+            sections.append("\n".join(lines))
+
+    # 7. Check failure samples
+    if checks:
+        failed_by_check: dict[str, list[CheckResult]] = defaultdict(list)
+        for c in checks:
+            if not c.passed:
+                failed_by_check[c.check_name].append(c)
+        if failed_by_check:
+            lines = ["## Check Failure Samples (up to 3 per check)"]
+            for name, failures in sorted(failed_by_check.items()):
+                lines.append(f"### {name}")
+                for f in failures[:3]:
+                    detail = _truncate(f.detail, 100)
+                    lines.append(
+                        f'- query="{f.query}", product={f.product_id}, detail: {detail}'
+                    )
+            sections.append("\n".join(lines))
+
+    # 8. Corrections
+    if correction_judgments:
+        lines = ["## Corrections"]
+        for cj in correction_judgments:
+            reason = _truncate(cj.reasoning, 120)
+            lines.append(
+                f'- "{cj.original_query}" -> "{cj.corrected_query}": '
+                f"{cj.verdict} ({reason})"
+            )
+        sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
+
+
+# ── Comparison report payload ────────────────────────────────────
+
+
+def _build_comparison_payload(
+    metrics_a: list[MetricResult],
+    metrics_b: list[MetricResult],
+    checks_a: list[CheckResult] | None,
+    checks_b: list[CheckResult] | None,
+    judgments_a: list[JudgmentRecord] | None,
+    judgments_b: list[JudgmentRecord] | None,
+    comparison_checks: list[CheckResult],
+    config_a: str,
+    config_b: str,
+    corrections_a: list[CorrectionJudgment] | None,
+    corrections_b: list[CorrectionJudgment] | None,
+) -> str:
+    """Build a structured text payload for the comparison summary LLM call."""
+    sections: list[str] = []
+
+    metrics_b_lookup = {m.metric_name: m for m in metrics_b}
+
+    # 9. Aggregate baseline
+    lines = [f"## Aggregate Metrics ({config_a} vs {config_b})"]
+    for m_a in metrics_a:
+        m_b = metrics_b_lookup.get(m_a.metric_name)
+        if m_b:
+            lines.append(
+                f"- {m_a.metric_name}: {config_a}={m_a.value:.4f}, "
+                f"{config_b}={m_b.value:.4f}"
+            )
+    sections.append("\n".join(lines))
+
+    # 10. Metric deltas
+    lines = ["## Metric Deltas"]
+    for m_a in metrics_a:
+        m_b = metrics_b_lookup.get(m_a.metric_name)
+        if m_b:
+            delta = m_b.value - m_a.value
+            pct = (delta / m_a.value * 100) if m_a.value != 0 else 0.0
+            lines.append(f"- {m_a.metric_name}: delta={delta:+.4f} ({pct:+.1f}%)")
+    sections.append("\n".join(lines))
+
+    # 11. Win/loss/tie
+    ndcg_a = next((m for m in metrics_a if m.metric_name == "ndcg@10"), None)
+    ndcg_b = next((m for m in metrics_b if m.metric_name == "ndcg@10"), None)
+    if ndcg_a and ndcg_b and ndcg_a.per_query and ndcg_b.per_query:
+        wins = losses = ties = 0
+        for q in ndcg_a.per_query:
+            if q in ndcg_b.per_query:
+                d = ndcg_b.per_query[q] - ndcg_a.per_query[q]
+                if d > 0.001:
+                    wins += 1
+                elif d < -0.001:
+                    losses += 1
+                else:
+                    ties += 1
+        total = wins + losses + ties
+        if total > 0:
+            sections.append(
+                f"## Win/Loss/Tie (NDCG@10, {total} queries)\n"
+                f"- {config_b} wins: {wins} ({wins / total * 100:.0f}%)\n"
+                f"- {config_a} wins: {losses} ({losses / total * 100:.0f}%)\n"
+                f"- Ties: {ties} ({ties / total * 100:.0f}%)"
+            )
+
+    # 12. Top 5 improvements + regressions
+    if ndcg_a and ndcg_b and ndcg_a.per_query and ndcg_b.per_query:
+        deltas: list[tuple[str, float, float, float]] = []
+        for q in ndcg_a.per_query:
+            if q in ndcg_b.per_query:
+                d = ndcg_b.per_query[q] - ndcg_a.per_query[q]
+                deltas.append((q, ndcg_a.per_query[q], ndcg_b.per_query[q], d))
+        deltas.sort(key=lambda x: x[3])
+
+        regressions = [x for x in deltas if x[3] < -0.001][:5]
+        improvements = [x for x in reversed(deltas) if x[3] > 0.001][:5]
+
+        if improvements:
+            lines = ["## Top Improvements"]
+            for q, va, vb, d in improvements:
+                lines.append(
+                    f'- "{q}": {config_a}={va:.4f} -> {config_b}={vb:.4f} ({d:+.4f})'
+                )
+            sections.append("\n".join(lines))
+
+        if regressions:
+            lines = ["## Top Regressions"]
+            for q, va, vb, d in regressions:
+                lines.append(
+                    f'- "{q}": {config_a}={va:.4f} -> {config_b}={vb:.4f} ({d:+.4f})'
+                )
+            sections.append("\n".join(lines))
+
+    # 13. Check deltas
+    if checks_a or checks_b:
+        fail_a: dict[str, int] = defaultdict(int)
+        fail_b: dict[str, int] = defaultdict(int)
+        for c in checks_a or []:
+            if not c.passed:
+                fail_a[c.check_name] += 1
+        for c in checks_b or []:
+            if not c.passed:
+                fail_b[c.check_name] += 1
+        all_names = sorted(set(fail_a.keys()) | set(fail_b.keys()))
+        if all_names:
+            lines = ["## Check Failure Deltas"]
+            for name in all_names:
+                a_count = fail_a.get(name, 0)
+                b_count = fail_b.get(name, 0)
+                delta = b_count - a_count
+                lines.append(
+                    f"- {name}: {config_a}={a_count}, "
+                    f"{config_b}={b_count} (delta={delta:+d})"
+                )
+            sections.append("\n".join(lines))
+
+    # 14. Metrics by query type (both)
+    all_types: set[str] = set()
+    for m in metrics_a + metrics_b:
+        all_types.update(m.by_query_type.keys())
+    if all_types:
+        lines = ["## Metrics by Query Type"]
+        for m_a in metrics_a:
+            m_b = metrics_b_lookup.get(m_a.metric_name)
+            if m_b and (m_a.by_query_type or m_b.by_query_type):
+                for qt in sorted(all_types):
+                    qt_va = m_a.by_query_type.get(qt)
+                    qt_vb = m_b.by_query_type.get(qt)
+                    if qt_va is not None and qt_vb is not None:
+                        lines.append(
+                            f"- {m_a.metric_name}/{qt}: "
+                            f"{config_a}={qt_va:.4f}, {config_b}={qt_vb:.4f}"
+                        )
+        sections.append("\n".join(lines))
+
+    # Corrections
+    for label, cjs in [
+        (config_a, corrections_a),
+        (config_b, corrections_b),
+    ]:
+        if cjs:
+            lines = [f"## Corrections ({label})"]
+            for cj in cjs:
+                reason = _truncate(cj.reasoning, 120)
+                lines.append(
+                    f'- "{cj.original_query}" -> "{cj.corrected_query}": '
+                    f"{cj.verdict} ({reason})"
+                )
+            sections.append("\n".join(lines))
+
+    return "\n\n".join(sections)
+
+
+# ── Response parsing ─────────────────────────────────────────────
+
+
+def _parse_summary_response(text: str) -> str | None:
+    """Parse LLM response. Returns ``None`` if no insights or too short."""
+    stripped = text.strip()
+    if not stripped:
+        return None
+    if _NO_INSIGHTS_SENTINEL in stripped:
+        return None
+    if len(stripped) < _MIN_SUMMARY_LENGTH:
+        return None
+    return stripped
+
+
+# ── HTML conversion ──────────────────────────────────────────────
+
+
+def summary_bullets_to_html(text: str) -> str:
+    """Convert markdown bullet list to safe HTML.
+
+    Each line starting with ``- `` becomes an ``<li>``.
+    Non-bullet lines become ``<p>`` tags.
+    All text content is HTML-escaped.
+    """
+    lines = text.strip().splitlines()
+    in_list = False
+    parts: list[str] = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            if in_list:
+                parts.append("</ul>")
+                in_list = False
+            continue
+
+        if stripped.startswith("- "):
+            if not in_list:
+                parts.append("<ul>")
+                in_list = True
+            content = html.escape(stripped[2:].strip())
+            parts.append(f"<li>{content}</li>")
+        else:
+            if in_list:
+                parts.append("</ul>")
+                in_list = False
+            parts.append(f"<p>{html.escape(stripped)}</p>")
+
+    if in_list:
+        parts.append("</ul>")
+
+    return "\n".join(parts)
+
+
+# ── Public API ───────────────────────────────────────────────────
+
+
+def generate_summary(
+    client: LLMClient,
+    metrics: list[MetricResult],
+    checks: list[CheckResult],
+    judgments: list[JudgmentRecord] | None = None,
+    correction_judgments: list[CorrectionJudgment] | None = None,
+    run_metadata: Mapping[str, object] | None = None,
+) -> str | None:
+    """Generate an AI summary for a single-config evaluation report.
+
+    Returns a markdown bullet string, or ``None`` if the LLM finds
+    nothing insightful (or on any error).
+    """
+    payload = _build_single_payload(
+        metrics, checks, judgments, correction_judgments, run_metadata
+    )
+    if not payload.strip():
+        return None
+
+    system_prompt = load_prompt("reporting/summary.md")
+    response = client.complete(system_prompt, payload, max_tokens=_SUMMARY_MAX_TOKENS)
+    logger.debug(
+        "summary llm call: tokens=%d+%d",
+        response.input_tokens,
+        response.output_tokens,
+    )
+    return _parse_summary_response(response.content)
+
+
+def generate_comparison_summary(
+    client: LLMClient,
+    metrics_a: list[MetricResult],
+    metrics_b: list[MetricResult],
+    checks_a: list[CheckResult] | None,
+    checks_b: list[CheckResult] | None,
+    judgments_a: list[JudgmentRecord] | None,
+    judgments_b: list[JudgmentRecord] | None,
+    comparison_checks: list[CheckResult],
+    config_a: str,
+    config_b: str,
+    corrections_a: list[CorrectionJudgment] | None = None,
+    corrections_b: list[CorrectionJudgment] | None = None,
+) -> str | None:
+    """Generate an AI summary for an A/B comparison report.
+
+    Returns a markdown bullet string, or ``None`` if the LLM finds
+    nothing insightful (or on any error).
+    """
+    payload = _build_comparison_payload(
+        metrics_a,
+        metrics_b,
+        checks_a,
+        checks_b,
+        judgments_a,
+        judgments_b,
+        comparison_checks,
+        config_a,
+        config_b,
+        corrections_a,
+        corrections_b,
+    )
+    if not payload.strip():
+        return None
+
+    system_prompt = load_prompt("reporting/comparison_summary.md")
+    response = client.complete(system_prompt, payload, max_tokens=_SUMMARY_MAX_TOKENS)
+    logger.debug(
+        "comparison summary llm call: tokens=%d+%d",
+        response.input_tokens,
+        response.output_tokens,
+    )
+    return _parse_summary_response(response.content)

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -32,6 +32,17 @@ _VISIBLE_BULLETS = 3
 # per-query NDCG reflects it.
 _SUMMARY_EXCLUDED_CHECKS: frozenset[str] = frozenset({"text_overlap"})
 
+# Display names for checks in the summary payload.  Lets us clarify
+# semantics for the LLM without renaming the actual check.
+_SUMMARY_CHECK_DISPLAY: dict[str, str] = {
+    "duplicate": "near_duplicate",
+}
+
+
+def _check_display_name(name: str) -> str:
+    """Return the display name for a check in the summary payload."""
+    return _SUMMARY_CHECK_DISPLAY.get(name, name)
+
 
 def _truncate(text: str, max_len: int) -> str:
     """Truncate *text* to *max_len* characters, appending '...' if cut."""
@@ -99,7 +110,8 @@ def _build_single_payload(
             key = "passed" if c.passed else "failed"
             check_counts[c.check_name][key] += 1
         lines = ["## Check Summary"]
-        for name, counts in sorted(check_counts.items()):
+        for raw_name, counts in sorted(check_counts.items()):
+            name = _check_display_name(raw_name)
             if counts["passed"] == 0:
                 # Detection-only check (only emits failures when an issue
                 # is found).  Reporting "0 passed" would mislead the LLM
@@ -130,8 +142,9 @@ def _build_single_payload(
 
         per_query_failed: dict[str, list[str]] = defaultdict(list)
         for c in checks:
-            if not c.passed and c.check_name not in per_query_failed[c.query]:
-                per_query_failed[c.query].append(c.check_name)
+            display = _check_display_name(c.check_name)
+            if not c.passed and display not in per_query_failed[c.query]:
+                per_query_failed[c.query].append(display)
 
         sorted_queries = sorted(ndcg.per_query.items(), key=lambda x: x[1])[:5]
         lines = ["## Worst 5 Queries (by NDCG@10)"]
@@ -190,8 +203,8 @@ def _build_single_payload(
                 failed_by_check[c.check_name].append(c)
         if failed_by_check:
             lines = ["## Check Failure Samples (up to 3 per check)"]
-            for name, failures in sorted(failed_by_check.items()):
-                lines.append(f"### {name}")
+            for raw_name, failures in sorted(failed_by_check.items()):
+                lines.append(f"### {_check_display_name(raw_name)}")
                 for f in failures[:3]:
                     detail = _truncate(f.detail, 100)
                     lines.append(
@@ -348,12 +361,13 @@ def _build_comparison_payload(
         all_names = sorted(set(fail_a.keys()) | set(fail_b.keys()))
         if all_names:
             lines = ["## Check Failure Deltas"]
-            for name in all_names:
-                a_count = fail_a.get(name, 0)
-                b_count = fail_b.get(name, 0)
+            for raw_name in all_names:
+                display = _check_display_name(raw_name)
+                a_count = fail_a.get(raw_name, 0)
+                b_count = fail_b.get(raw_name, 0)
                 delta = b_count - a_count
                 lines.append(
-                    f"- {name}: {config_a}={a_count}, "
+                    f"- {display}: {config_a}={a_count}, "
                     f"{config_b}={b_count} (delta={delta:+d})"
                 )
             sections.append("\n".join(lines))

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -489,7 +489,7 @@ def summary_bullets_to_html(text: str) -> str:
     """
     lines = text.strip().splitlines()
     in_list = False
-    in_details = False
+    in_overflow = False
     bullet_count = 0
     parts: list[str] = []
 
@@ -499,20 +499,19 @@ def summary_bullets_to_html(text: str) -> str:
             if in_list:
                 parts.append("</ul>")
                 in_list = False
-            # Never close <details> on blank lines — only at the end
+            # Never close overflow on blank lines — only at the end
             continue
 
         if stripped.startswith("- "):
             bullet_count += 1
             if bullet_count == _VISIBLE_BULLETS + 1:
-                # Close the visible list, open collapsible section
+                # Close the visible list, open hidden overflow div
                 if in_list:
                     parts.append("</ul>")
-                parts.append('<details class="summary-more">')
-                parts.append('<summary class="summary-toggle">Show more</summary>')
+                parts.append('<div class="summary-overflow" hidden>')
                 parts.append("<ul>")
                 in_list = True
-                in_details = True
+                in_overflow = True
             elif not in_list:
                 parts.append("<ul>")
                 in_list = True
@@ -522,15 +521,24 @@ def summary_bullets_to_html(text: str) -> str:
             if in_list:
                 parts.append("</ul>")
                 in_list = False
-            if in_details:
-                parts.append("</details>")
-                in_details = False
+            if in_overflow:
+                parts.append("</div>")
+                in_overflow = False
             parts.append(f"<p>{_inline_markdown(html.escape(stripped))}</p>")
 
     if in_list:
         parts.append("</ul>")
-    if in_details:
-        parts.append("</details>")
+    if in_overflow:
+        parts.append("</div>")
+        parts.append(
+            '<button class="summary-toggle" onclick="'
+            "const o=this.previousElementSibling;"
+            "const v=o.hidden;"
+            "o.hidden=!v;"
+            "this.textContent=v?"
+            "'\\u25BE Show less':'\\u25B8 Show more'"
+            '">&#x25B8; Show more</button>'
+        )
 
     return "\n".join(parts)
 

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -460,14 +460,19 @@ def _parse_summary_response(text: str) -> str | None:
 
 
 def _inline_markdown(text: str) -> str:
-    """Convert ``**bold**`` in already-escaped HTML text to ``<strong>`` tags."""
-    # The text is already HTML-escaped, so ** are literal asterisks.
-    # Use non-greedy match to handle multiple bold spans per line.
-    return re.sub(
-        r"\*\*(.+?)\*\*",
-        r"<strong>\1</strong>",
-        text,
-    )
+    """Convert inline markdown in already-escaped HTML text to HTML tags.
+
+    Handles ``**bold**``, ``*italic*``, and ``` `code` ```.
+    The text is already HTML-escaped so the markers are literal characters.
+    Order matters: bold (``**``) must be processed before italic (``*``).
+    """
+    # Bold: **text**
+    text = re.sub(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", text)
+    # Italic: *text* (but not inside <strong> tags' asterisks, already consumed)
+    text = re.sub(r"\*(.+?)\*", r"<em>\1</em>", text)
+    # Inline code: `text`
+    text = re.sub(r"`(.+?)`", r"<code>\1</code>", text)
+    return text
 
 
 def summary_bullets_to_html(text: str) -> str:

--- a/src/veritail/reporting/summary.py
+++ b/src/veritail/reporting/summary.py
@@ -26,6 +26,12 @@ _NO_INSIGHTS_SENTINEL = "__NO_INSIGHTS__"
 _MIN_SUMMARY_LENGTH = 20
 _VISIBLE_BULLETS = 3
 
+# Checks that are redundant with the LLM judge scores and would add noise
+# to the summary payload.  text_overlap is a crude keyword-matching proxy
+# for relevance — the judge already evaluates this more accurately and the
+# per-query NDCG reflects it.
+_SUMMARY_EXCLUDED_CHECKS: frozenset[str] = frozenset({"text_overlap"})
+
 
 def _truncate(text: str, max_len: int) -> str:
     """Truncate *text* to *max_len* characters, appending '...' if cut."""
@@ -51,6 +57,9 @@ def _build_single_payload(
 ) -> str:
     """Build a structured text payload for the single-report summary LLM call."""
     sections: list[str] = []
+
+    # Filter out checks that are redundant with judge scores.
+    checks = [c for c in checks if c.check_name not in _SUMMARY_EXCLUDED_CHECKS]
 
     # 1. Score distribution
     if judgments:
@@ -91,12 +100,18 @@ def _build_single_payload(
             check_counts[c.check_name][key] += 1
         lines = ["## Check Summary"]
         for name, counts in sorted(check_counts.items()):
-            total_c = counts["passed"] + counts["failed"]
-            fail_rate = counts["failed"] / total_c * 100 if total_c > 0 else 0
-            lines.append(
-                f"- {name}: {counts['passed']} passed, "
-                f"{counts['failed']} failed ({fail_rate:.0f}% fail rate)"
-            )
+            if counts["passed"] == 0:
+                # Detection-only check (only emits failures when an issue
+                # is found).  Reporting "0 passed" would mislead the LLM
+                # into thinking every result failed.
+                lines.append(f"- {name}: {counts['failed']} findings")
+            else:
+                total_c = counts["passed"] + counts["failed"]
+                fail_rate = counts["failed"] / total_c * 100 if total_c > 0 else 0
+                lines.append(
+                    f"- {name}: {counts['passed']} passed, "
+                    f"{counts['failed']} failed ({fail_rate:.0f}% fail rate)"
+                )
         sections.append("\n".join(lines))
 
     # 4. Worst 5 queries (by NDCG@10)
@@ -216,6 +231,17 @@ def _build_comparison_payload(
 ) -> str:
     """Build a structured text payload for the comparison summary LLM call."""
     sections: list[str] = []
+
+    # Filter out checks that are redundant with judge scores.
+    def _filter_checks(
+        cs: list[CheckResult] | None,
+    ) -> list[CheckResult] | None:
+        if cs is None:
+            return None
+        return [c for c in cs if c.check_name not in _SUMMARY_EXCLUDED_CHECKS]
+
+    checks_a = _filter_checks(checks_a)
+    checks_b = _filter_checks(checks_b)
 
     metrics_b_lookup = {m.metric_name: m for m in metrics_b}
 

--- a/src/veritail/reporting/templates/autocomplete_report.html
+++ b/src/veritail/reporting/templates/autocomplete_report.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Autocomplete Evaluation Report</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='80' fill='%23818CF8'>V</text></svg>">
     <style>{{ shared_css|safe }}</style>
 </head>
 <body>

--- a/src/veritail/reporting/templates/report.html
+++ b/src/veritail/reporting/templates/report.html
@@ -13,6 +13,7 @@
 
     <nav class="report-nav" id="report-nav">
       <ul>
+        {% if summary %}<li><a href="#section-summary">Summary</a></li>{% endif %}
         <li><a href="#section-metrics">Metrics</a></li>
         {% if win_loss %}<li><a href="#section-win-loss">Win/Loss</a></li>{% endif %}
         {% if overlap_summary %}<li><a href="#section-overlap">Overlap</a></li>{% endif %}
@@ -31,6 +32,15 @@
     {% if sibling_report %}
     <div class="banner-link">
         This run also evaluated autocomplete. <a href="{{ sibling_report }}">View Autocomplete Report &rarr;</a>
+    </div>
+    {% endif %}
+
+    {% if summary %}
+    <div class="summary-card" id="section-summary">
+        <div style="display:flex; align-items:center; gap:8px; margin-bottom:12px;">
+            <span class="summary-badge">AI Summary</span>
+        </div>
+        <div class="summary-content">{{ summary|safe }}</div>
     </div>
     {% endif %}
 
@@ -478,6 +488,7 @@
 
     <nav class="report-nav" id="report-nav">
       <ul>
+        {% if summary %}<li><a href="#section-summary">Summary</a></li>{% endif %}
         {% if kpi_cards %}<li><a href="#section-kpi">Overview</a></li>{% endif %}
         <li><a href="#section-metrics">Metrics</a></li>
         {% if position_chart %}<li><a href="#section-position">Position</a></li>{% endif %}
@@ -494,6 +505,15 @@
     {% if sibling_report %}
     <div class="banner-link">
         This run also evaluated autocomplete. <a href="{{ sibling_report }}">View Autocomplete Report &rarr;</a>
+    </div>
+    {% endif %}
+
+    {% if summary %}
+    <div class="summary-card" id="section-summary">
+        <div style="display:flex; align-items:center; gap:8px; margin-bottom:12px;">
+            <span class="summary-badge">AI Summary</span>
+        </div>
+        <div class="summary-content">{{ summary|safe }}</div>
     </div>
     {% endif %}
 

--- a/src/veritail/reporting/templates/report.html
+++ b/src/veritail/reporting/templates/report.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Search Evaluation Report</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='80' fill='%23818CF8'>V</text></svg>">
     <style>{{ shared_css|safe }}</style>
 </head>
 <body>

--- a/src/veritail/reporting/templates/report.html
+++ b/src/veritail/reporting/templates/report.html
@@ -488,8 +488,8 @@
 
     <nav class="report-nav" id="report-nav">
       <ul>
-        {% if summary %}<li><a href="#section-summary">Summary</a></li>{% endif %}
         {% if kpi_cards %}<li><a href="#section-kpi">Overview</a></li>{% endif %}
+        {% if summary %}<li><a href="#section-summary">Summary</a></li>{% endif %}
         <li><a href="#section-metrics">Metrics</a></li>
         {% if position_chart %}<li><a href="#section-position">Position</a></li>{% endif %}
         {% if ndcg_histogram %}<li><a href="#section-ndcg-dist">NDCG Dist.</a></li>{% endif %}
@@ -508,15 +508,6 @@
     </div>
     {% endif %}
 
-    {% if summary %}
-    <div class="summary-card" id="section-summary">
-        <div style="display:flex; align-items:center; gap:8px; margin-bottom:12px;">
-            <span class="summary-badge">AI Summary</span>
-        </div>
-        <div class="summary-content">{{ summary|safe }}</div>
-    </div>
-    {% endif %}
-
     {% if kpi_cards %}
     <div class="kpi-grid" id="section-kpi">
       {% for card in kpi_cards %}
@@ -526,6 +517,15 @@
         {% if card.ci %}<div class="kpi-card__ci">{{ card.ci }}</div>{% endif %}
       </div>
       {% endfor %}
+    </div>
+    {% endif %}
+
+    {% if summary %}
+    <div class="summary-card" id="section-summary">
+        <div style="display:flex; align-items:center; gap:8px; margin-bottom:12px;">
+            <span class="summary-badge">AI Summary</span>
+        </div>
+        <div class="summary-content">{{ summary|safe }}</div>
     </div>
     {% endif %}
 

--- a/src/veritail/reporting/templates/report.html
+++ b/src/veritail/reporting/templates/report.html
@@ -880,8 +880,7 @@
             if (!container || !paginationEl) return;
 
             var items = container.querySelectorAll('.paginated-item');
-            if (items.length <= PER_PAGE) return;
-
+            var paginated = items.length > PER_PAGE;
             var totalPages = Math.ceil(items.length / PER_PAGE);
             var currentPage = 1;
 
@@ -904,8 +903,10 @@
                 if (!el) return;
                 for (var i = 0; i < items.length; i++) {
                     if (items[i] === el || items[i].contains(el)) {
-                        var page = Math.floor(i / PER_PAGE) + 1;
-                        showPage(page, true);
+                        if (paginated) {
+                            var page = Math.floor(i / PER_PAGE) + 1;
+                            showPage(page, true);
+                        }
                         el.setAttribute('open', '');
                         setTimeout(function() { el.scrollIntoView({behavior: 'smooth', block: 'start'}); }, 50);
                         return;
@@ -939,13 +940,6 @@
                 paginationEl.innerHTML = html;
             }
 
-            paginationEl.addEventListener('click', function(e) {
-                var btn = e.target.closest('button');
-                if (btn && !btn.disabled && btn.dataset.page) {
-                    showPage(parseInt(btn.dataset.page, 10));
-                }
-            });
-
             document.addEventListener('click', function(e) {
                 var link = e.target.closest('a[data-judgment-anchor]');
                 if (link) {
@@ -954,14 +948,23 @@
                 }
             });
 
-            showPage(1);
-
             if (location.hash) {
                 var anchorId = location.hash.substring(1);
                 if (anchorId.indexOf('query-') === 0) {
                     revealAnchor(anchorId);
                 }
             }
+
+            if (!paginated) return;
+
+            paginationEl.addEventListener('click', function(e) {
+                var btn = e.target.closest('button');
+                if (btn && !btn.disabled && btn.dataset.page) {
+                    showPage(parseInt(btn.dataset.page, 10));
+                }
+            });
+
+            showPage(1);
         }
 
         paginate('judgment-list', 'judgment-pagination');

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -333,6 +333,7 @@ class TestCLI:
                     "test-model",
                     "--context",
                     str(context_file),
+                    "--no-summary",
                 ],
             )
 
@@ -819,6 +820,7 @@ class TestCLI:
                     "test-model",
                     "--sample",
                     "2",
+                    "--no-summary",
                 ],
             )
 
@@ -873,6 +875,7 @@ class TestCLI:
                     "test-model",
                     "--sample",
                     "10",
+                    "--no-summary",
                 ],
             )
 

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -297,7 +297,7 @@ class TestBuildSinglePayload:
             None,
         )
         # laptop has scores [0, 1] which has higher variance than others
-        assert "High-Variance" in payload
+        assert "Mixed-Relevance Queries" in payload
 
     def test_includes_position_decay(self):
         payload = _build_single_payload(
@@ -347,7 +347,7 @@ class TestBuildSinglePayload:
         )
         assert "Score Distribution" not in payload
         assert "Worst 5 Queries" not in payload
-        assert "High-Variance" not in payload
+        assert "Mixed-Relevance" not in payload
 
 
 # ── _build_comparison_payload ────────────────────────────────────

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -491,12 +491,7 @@ class TestGenerateSummary:
     def test_returns_none_on_exception(self):
         client = MagicMock(spec=LLMClient)
         client.complete.side_effect = RuntimeError("API error")
-        try:
-            result = generate_summary(client, _make_metrics(), _make_checks())
-        except RuntimeError:
-            # The function itself doesn't catch - the CLI does
-            result = None
-        # Either way, we don't crash
+        result = generate_summary(client, _make_metrics(), _make_checks())
         assert result is None
 
 
@@ -525,6 +520,23 @@ class TestGenerateComparisonSummary:
 
     def test_returns_none_on_no_insights(self):
         client = _mock_client("__NO_INSIGHTS__")
+        result = generate_comparison_summary(
+            client,
+            _make_metrics(),
+            _make_metrics(),
+            checks_a=None,
+            checks_b=None,
+            judgments_a=None,
+            judgments_b=None,
+            comparison_checks=[],
+            config_a="A",
+            config_b="B",
+        )
+        assert result is None
+
+    def test_returns_none_on_exception(self):
+        client = MagicMock(spec=LLMClient)
+        client.complete.side_effect = RuntimeError("API error")
         result = generate_comparison_summary(
             client,
             _make_metrics(),

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -1,0 +1,700 @@
+"""Tests for LLM-powered report summary generation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from veritail.llm.client import LLMClient, LLMResponse
+from veritail.reporting.summary import (
+    _build_comparison_payload,
+    _build_single_payload,
+    _parse_summary_response,
+    generate_comparison_summary,
+    generate_summary,
+    summary_bullets_to_html,
+)
+from veritail.types import (
+    CheckResult,
+    CorrectionJudgment,
+    JudgmentRecord,
+    MetricResult,
+    SearchResult,
+)
+
+# ── Fixtures ─────────────────────────────────────────────────────
+
+
+def _product(position: int = 0, product_id: str = "SKU-1") -> SearchResult:
+    return SearchResult(
+        product_id=product_id,
+        title="Test Product",
+        description="A product",
+        category="shoes",
+        price=49.99,
+        position=position,
+    )
+
+
+def _make_metrics() -> list[MetricResult]:
+    return [
+        MetricResult(
+            metric_name="ndcg@10",
+            value=0.75,
+            per_query={"shoes": 0.9, "laptop": 0.5, "socks": 0.85},
+            by_query_type={"broad": 0.80, "navigational": 0.70},
+            ci_lower=0.65,
+            ci_upper=0.85,
+        ),
+        MetricResult(
+            metric_name="mrr",
+            value=0.72,
+            per_query={"shoes": 0.8, "laptop": 0.6, "socks": 0.75},
+            by_query_type={"broad": 0.75, "navigational": 0.69},
+        ),
+    ]
+
+
+def _make_checks() -> list[CheckResult]:
+    return [
+        CheckResult(
+            check_name="zero_results",
+            query="shoes",
+            product_id=None,
+            passed=True,
+            detail="OK",
+        ),
+        CheckResult(
+            check_name="text_overlap",
+            query="laptop",
+            product_id="SKU-1",
+            passed=False,
+            detail="Low keyword overlap: 10%",
+        ),
+        CheckResult(
+            check_name="price_outlier",
+            query="laptop",
+            product_id="SKU-2",
+            passed=False,
+            detail="Price $999 is 3.5x the median ($285)",
+        ),
+    ]
+
+
+def _make_judgments() -> list[JudgmentRecord]:
+    return [
+        JudgmentRecord(
+            query="shoes",
+            product=_product(0, "SKU-1"),
+            score=3,
+            reasoning="Highly relevant running shoes.",
+            model="gpt-4o",
+            experiment="test",
+            query_type="broad",
+        ),
+        JudgmentRecord(
+            query="shoes",
+            product=_product(1, "SKU-2"),
+            score=2,
+            reasoning="Partially relevant.",
+            model="gpt-4o",
+            experiment="test",
+            query_type="broad",
+        ),
+        JudgmentRecord(
+            query="laptop",
+            product=_product(0, "SKU-3"),
+            score=1,
+            reasoning="Low relevance laptop case.",
+            model="gpt-4o",
+            experiment="test",
+            query_type="navigational",
+        ),
+        JudgmentRecord(
+            query="laptop",
+            product=_product(1, "SKU-4"),
+            score=0,
+            reasoning="Irrelevant monitor stand.",
+            model="gpt-4o",
+            experiment="test",
+            query_type="navigational",
+        ),
+        JudgmentRecord(
+            query="socks",
+            product=_product(0, "SKU-5"),
+            score=3,
+            reasoning="Perfect match.",
+            model="gpt-4o",
+            experiment="test",
+            query_type="broad",
+        ),
+    ]
+
+
+def _make_corrections() -> list[CorrectionJudgment]:
+    return [
+        CorrectionJudgment(
+            original_query="laptp",
+            corrected_query="laptop",
+            verdict="appropriate",
+            reasoning="Clear typo correction.",
+            model="gpt-4o",
+            experiment="test",
+        ),
+    ]
+
+
+def _mock_client(response_text: str) -> LLMClient:
+    client = MagicMock(spec=LLMClient)
+    client.complete.return_value = LLMResponse(
+        content=response_text,
+        model="gpt-4o",
+        input_tokens=100,
+        output_tokens=50,
+    )
+    return client
+
+
+# ── _parse_summary_response ──────────────────────────────────────
+
+
+class TestParseSummaryResponse:
+    def test_returns_none_for_empty_string(self):
+        assert _parse_summary_response("") is None
+
+    def test_returns_none_for_whitespace(self):
+        assert _parse_summary_response("   \n  ") is None
+
+    def test_returns_none_for_no_insights_sentinel(self):
+        assert _parse_summary_response("__NO_INSIGHTS__") is None
+
+    def test_returns_none_for_sentinel_with_surrounding_text(self):
+        assert _parse_summary_response("Nothing found.\n__NO_INSIGHTS__") is None
+
+    def test_returns_none_for_short_text(self):
+        assert _parse_summary_response("Too short.") is None
+
+    def test_returns_valid_summary(self):
+        text = "- This is a meaningful insight about the search quality data."
+        result = _parse_summary_response(text)
+        assert result == text
+
+    def test_strips_whitespace(self):
+        text = "  - Insight about data patterns.\n- Another insight.  "
+        result = _parse_summary_response(text)
+        assert result == text.strip()
+
+
+# ── summary_bullets_to_html ──────────────────────────────────────
+
+
+class TestSummaryBulletsToHtml:
+    def test_converts_bullets_to_list(self):
+        text = "- First bullet\n- Second bullet"
+        result = summary_bullets_to_html(text)
+        assert "<ul>" in result
+        assert "<li>First bullet</li>" in result
+        assert "<li>Second bullet</li>" in result
+        assert "</ul>" in result
+
+    def test_escapes_html_in_bullets(self):
+        text = "- Contains <script>alert('xss')</script> in text"
+        result = summary_bullets_to_html(text)
+        assert "<script>" not in result
+        assert "&lt;script&gt;" in result
+
+    def test_non_bullet_lines_become_paragraphs(self):
+        text = "Some header text\n- A bullet"
+        result = summary_bullets_to_html(text)
+        assert "<p>Some header text</p>" in result
+        assert "<li>A bullet</li>" in result
+
+    def test_empty_lines_close_list(self):
+        text = "- First group\n\n- Second group"
+        result = summary_bullets_to_html(text)
+        # Should have two separate <ul> blocks
+        assert result.count("<ul>") == 2
+        assert result.count("</ul>") == 2
+
+    def test_empty_input(self):
+        result = summary_bullets_to_html("")
+        assert result == ""
+
+    def test_mixed_content(self):
+        text = "Header\n- Bullet 1\n- Bullet 2\nFooter"
+        result = summary_bullets_to_html(text)
+        assert "<p>Header</p>" in result
+        assert "<li>Bullet 1</li>" in result
+        assert "<li>Bullet 2</li>" in result
+        assert "<p>Footer</p>" in result
+
+
+# ── _build_single_payload ────────────────────────────────────────
+
+
+class TestBuildSinglePayload:
+    def test_includes_score_distribution(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            _make_judgments(),
+            None,
+            None,
+        )
+        assert "Score Distribution" in payload
+        assert "5 judgments" in payload
+
+    def test_includes_metrics(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            None,
+            None,
+            None,
+        )
+        assert "ndcg@10: 0.7500" in payload
+        assert "CI: 0.6500-0.8500" in payload
+
+    def test_includes_by_query_type(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            [],
+            None,
+            None,
+            None,
+        )
+        assert "broad: 0.8000" in payload
+        assert "navigational: 0.7000" in payload
+
+    def test_includes_check_summary(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            None,
+            None,
+            None,
+        )
+        assert "Check Summary" in payload
+        assert "text_overlap" in payload
+        assert "price_outlier" in payload
+
+    def test_includes_worst_queries(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            _make_judgments(),
+            None,
+            None,
+        )
+        assert "Worst 5 Queries" in payload
+        assert '"laptop"' in payload
+
+    def test_includes_high_variance(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            _make_judgments(),
+            None,
+            None,
+        )
+        # laptop has scores [0, 1] which has higher variance than others
+        assert "High-Variance" in payload
+
+    def test_includes_position_decay(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            _make_judgments(),
+            None,
+            None,
+        )
+        assert "Average Score by Position" in payload
+        assert "Position 1" in payload
+
+    def test_includes_check_failure_samples(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            None,
+            None,
+            None,
+        )
+        assert "Check Failure Samples" in payload
+        assert "Low keyword overlap" in payload
+
+    def test_includes_corrections(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            None,
+            _make_corrections(),
+            None,
+        )
+        assert "Corrections" in payload
+        assert '"laptp"' in payload
+        assert "appropriate" in payload
+
+    def test_empty_payload_returns_empty_string(self):
+        payload = _build_single_payload([], [], None, None, None)
+        assert payload == ""
+
+    def test_no_judgments_skips_judgment_sections(self):
+        payload = _build_single_payload(
+            _make_metrics(),
+            _make_checks(),
+            None,
+            None,
+            None,
+        )
+        assert "Score Distribution" not in payload
+        assert "Worst 5 Queries" not in payload
+        assert "High-Variance" not in payload
+
+
+# ── _build_comparison_payload ────────────────────────────────────
+
+
+class TestBuildComparisonPayload:
+    def test_includes_aggregate_metrics(self):
+        metrics_a = _make_metrics()
+        metrics_b = [
+            MetricResult(
+                metric_name="ndcg@10",
+                value=0.80,
+                per_query={"shoes": 0.95, "laptop": 0.55, "socks": 0.90},
+                by_query_type={"broad": 0.85},
+            ),
+            MetricResult(
+                metric_name="mrr",
+                value=0.78,
+                per_query={"shoes": 0.85, "laptop": 0.65, "socks": 0.84},
+            ),
+        ]
+        payload = _build_comparison_payload(
+            metrics_a, metrics_b, None, None, None, None, [], "A", "B", None, None
+        )
+        assert "Aggregate Metrics" in payload
+        assert "A=0.7500" in payload
+        assert "B=0.8000" in payload
+
+    def test_includes_metric_deltas(self):
+        metrics_a = _make_metrics()
+        metrics_b = [
+            MetricResult(metric_name="ndcg@10", value=0.80),
+            MetricResult(metric_name="mrr", value=0.78),
+        ]
+        payload = _build_comparison_payload(
+            metrics_a, metrics_b, None, None, None, None, [], "A", "B", None, None
+        )
+        assert "Metric Deltas" in payload
+        assert "+0.0500" in payload
+
+    def test_includes_win_loss_tie(self):
+        metrics_a = [
+            MetricResult(
+                metric_name="ndcg@10",
+                value=0.75,
+                per_query={"shoes": 0.9, "laptop": 0.5},
+            ),
+        ]
+        metrics_b = [
+            MetricResult(
+                metric_name="ndcg@10",
+                value=0.80,
+                per_query={"shoes": 0.95, "laptop": 0.5},
+            ),
+        ]
+        payload = _build_comparison_payload(
+            metrics_a, metrics_b, None, None, None, None, [], "A", "B", None, None
+        )
+        assert "Win/Loss/Tie" in payload
+
+    def test_includes_check_deltas(self):
+        checks_a = [
+            CheckResult(
+                check_name="text_overlap",
+                query="q1",
+                product_id="p1",
+                passed=False,
+                detail="fail",
+            ),
+        ]
+        checks_b = [
+            CheckResult(
+                check_name="text_overlap",
+                query="q1",
+                product_id="p1",
+                passed=True,
+                detail="ok",
+            ),
+        ]
+        payload = _build_comparison_payload(
+            _make_metrics(),
+            _make_metrics(),
+            checks_a,
+            checks_b,
+            None,
+            None,
+            [],
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "Check Failure Deltas" in payload
+
+    def test_includes_query_type_metrics(self):
+        payload = _build_comparison_payload(
+            _make_metrics(),
+            _make_metrics(),
+            None,
+            None,
+            None,
+            None,
+            [],
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "Metrics by Query Type" in payload
+
+
+# ── generate_summary ─────────────────────────────────────────────
+
+
+class TestGenerateSummary:
+    def test_returns_summary_on_success(self):
+        client = _mock_client(
+            "- Navigational queries underperform broad queries by 10 points."
+        )
+        result = generate_summary(
+            client,
+            _make_metrics(),
+            _make_checks(),
+            judgments=_make_judgments(),
+        )
+        assert result is not None
+        assert "Navigational" in result
+        client.complete.assert_called_once()
+
+    def test_returns_none_on_no_insights(self):
+        client = _mock_client("__NO_INSIGHTS__")
+        result = generate_summary(client, _make_metrics(), _make_checks())
+        assert result is None
+
+    def test_returns_none_on_empty_payload(self):
+        client = _mock_client("some text")
+        result = generate_summary(client, [], [])
+        assert result is None
+        client.complete.assert_not_called()
+
+    def test_returns_none_on_exception(self):
+        client = MagicMock(spec=LLMClient)
+        client.complete.side_effect = RuntimeError("API error")
+        try:
+            result = generate_summary(client, _make_metrics(), _make_checks())
+        except RuntimeError:
+            # The function itself doesn't catch - the CLI does
+            result = None
+        # Either way, we don't crash
+        assert result is None
+
+
+# ── generate_comparison_summary ──────────────────────────────────
+
+
+class TestGenerateComparisonSummary:
+    def test_returns_summary_on_success(self):
+        client = _mock_client(
+            "- Config B improves broad queries but regresses navigational ones."
+        )
+        result = generate_comparison_summary(
+            client,
+            _make_metrics(),
+            _make_metrics(),
+            checks_a=_make_checks(),
+            checks_b=_make_checks(),
+            judgments_a=_make_judgments(),
+            judgments_b=_make_judgments(),
+            comparison_checks=[],
+            config_a="baseline",
+            config_b="experiment",
+        )
+        assert result is not None
+        assert "Config B" in result
+
+    def test_returns_none_on_no_insights(self):
+        client = _mock_client("__NO_INSIGHTS__")
+        result = generate_comparison_summary(
+            client,
+            _make_metrics(),
+            _make_metrics(),
+            checks_a=None,
+            checks_b=None,
+            judgments_a=None,
+            judgments_b=None,
+            comparison_checks=[],
+            config_a="A",
+            config_b="B",
+        )
+        assert result is None
+
+
+# ── Report integration ───────────────────────────────────────────
+
+
+class TestReportIntegration:
+    def test_single_terminal_includes_summary(self):
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            summary="- Key insight about search quality patterns.",
+        )
+        assert "AI Summary" in report
+        assert "Key insight" in report
+
+    def test_single_terminal_omits_summary_when_none(self):
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            summary=None,
+        )
+        assert "AI Summary" not in report
+
+    def test_single_html_includes_summary(self):
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            format="html",
+            summary="- HTML insight about patterns.",
+        )
+        assert 'class="summary-card"' in report
+        assert "AI Summary" in report
+        assert "HTML insight about patterns." in report
+
+    def test_single_html_omits_summary_when_none(self):
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            format="html",
+            summary=None,
+        )
+        assert 'class="summary-card"' not in report
+
+    def test_comparison_terminal_includes_summary(self):
+        from veritail.reporting.comparison import generate_comparison_report
+
+        report = generate_comparison_report(
+            _make_metrics(),
+            _make_metrics(),
+            [],
+            "A",
+            "B",
+            summary="- Comparison insight about configs.",
+        )
+        assert "AI Summary" in report
+        assert "Comparison insight" in report
+
+    def test_comparison_terminal_omits_summary_when_none(self):
+        from veritail.reporting.comparison import generate_comparison_report
+
+        report = generate_comparison_report(
+            _make_metrics(),
+            _make_metrics(),
+            [],
+            "A",
+            "B",
+            summary=None,
+        )
+        assert "AI Summary" not in report
+
+    def test_comparison_html_includes_summary(self):
+        from veritail.reporting.comparison import generate_comparison_report
+
+        report = generate_comparison_report(
+            _make_metrics(),
+            _make_metrics(),
+            [],
+            "A",
+            "B",
+            format="html",
+            summary="- HTML comparison insight.",
+        )
+        assert 'class="summary-card"' in report
+        assert "AI Summary" in report
+
+    def test_comparison_html_omits_summary_when_none(self):
+        from veritail.reporting.comparison import generate_comparison_report
+
+        report = generate_comparison_report(
+            _make_metrics(),
+            _make_metrics(),
+            [],
+            "A",
+            "B",
+            format="html",
+            summary=None,
+        )
+        assert 'class="summary-card"' not in report
+
+    def test_summary_html_escapes_xss(self):
+        from veritail.reporting.summary import summary_bullets_to_html
+
+        malicious = '- Contains <script>alert("xss")</script> injection.'
+        html = summary_bullets_to_html(malicious)
+        # The converted HTML should escape dangerous content
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+
+        # Also verify it renders safely in the full report
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            format="html",
+            summary=malicious,
+        )
+        # The summary-content div should not contain raw <script>
+        import re
+
+        summary_match = re.search(
+            r'class="summary-content">(.*?)</div>',
+            report,
+            re.DOTALL,
+        )
+        assert summary_match is not None
+        summary_html = summary_match.group(1)
+        assert "<script>" not in summary_html
+        assert "&lt;script&gt;" in summary_html
+
+    def test_summary_nav_link_present_in_single_html(self):
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            format="html",
+            summary="- An insight.",
+        )
+        assert 'href="#section-summary"' in report
+        assert ">Summary<" in report
+
+    def test_summary_nav_link_absent_when_no_summary(self):
+        from veritail.reporting.single import generate_single_report
+
+        report = generate_single_report(
+            _make_metrics(),
+            _make_checks(),
+            format="html",
+            summary=None,
+        )
+        assert 'href="#section-summary"' not in report

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -515,6 +515,112 @@ class TestBuildComparisonPayload:
         )
         assert "Metrics by Query Type" in payload
 
+    def test_includes_result_overlap(self):
+        comparison_checks = [
+            CheckResult(
+                check_name="result_overlap",
+                query="shoes",
+                product_id=None,
+                passed=True,
+                detail="Result overlap: 0.60 (6/10 shared)",
+            ),
+            CheckResult(
+                check_name="result_overlap",
+                query="laptop",
+                product_id=None,
+                passed=True,
+                detail="Result overlap: 0.40 (4/10 shared)",
+            ),
+        ]
+        payload = _build_comparison_payload(
+            _make_metrics(),
+            _make_metrics(),
+            None,
+            None,
+            None,
+            None,
+            comparison_checks,
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "Result Overlap" in payload
+        assert "Mean Jaccard: 0.50" in payload
+
+    def test_includes_position_shifts(self):
+        comparison_checks = [
+            CheckResult(
+                check_name="position_shift",
+                query="shoes",
+                product_id="SKU-1",
+                passed=False,
+                detail="Moved 3 positions (1 -> 4)",
+            ),
+        ]
+        payload = _build_comparison_payload(
+            _make_metrics(),
+            _make_metrics(),
+            None,
+            None,
+            None,
+            None,
+            comparison_checks,
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "Position Shifts" in payload
+        assert "3 positions" in payload
+
+    def test_includes_score_distributions(self):
+        payload = _build_comparison_payload(
+            _make_metrics(),
+            _make_metrics(),
+            None,
+            None,
+            _make_judgments(),
+            _make_judgments(),
+            [],
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "Score Distribution: A" in payload
+        assert "Score Distribution: B" in payload
+
+    def test_includes_significance_data(self):
+        metrics_a = [
+            MetricResult(
+                metric_name="ndcg@10",
+                value=0.50,
+                per_query={"q1": 0.3, "q2": 0.5, "q3": 0.7},
+            ),
+        ]
+        metrics_b = [
+            MetricResult(
+                metric_name="ndcg@10",
+                value=0.80,
+                per_query={"q1": 0.7, "q2": 0.8, "q3": 0.9},
+            ),
+        ]
+        payload = _build_comparison_payload(
+            metrics_a,
+            metrics_b,
+            None,
+            None,
+            None,
+            None,
+            [],
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "p=" in payload
+
 
 # ── generate_summary ─────────────────────────────────────────────
 

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -227,6 +227,18 @@ class TestSummaryBulletsToHtml:
         assert "<li>Bullet 2</li>" in result
         assert "<p>Footer</p>" in result
 
+    def test_bold_markdown_converted_to_strong(self):
+        text = "- **Important:** this is a key insight."
+        result = summary_bullets_to_html(text)
+        assert "<strong>Important:</strong> this is a key insight." in result
+        assert "**" not in result
+
+    def test_bold_xss_still_escaped(self):
+        text = '- **<script>alert("xss")</script>** bold attack'
+        result = summary_bullets_to_html(text)
+        assert "<script>" not in result
+        assert "<strong>&lt;script&gt;" in result
+
 
 # ── _build_single_payload ────────────────────────────────────────
 

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -259,6 +259,19 @@ class TestSummaryBulletsToHtml:
         assert result.index("<li>Four.</li>") > first_details
         assert result.index("<li>Five.</li>") > first_details
 
+    def test_blank_lines_between_bullets_stay_collapsed(self):
+        """LLMs typically separate bullets with blank lines."""
+        text = "- One.\n\n- Two.\n\n- Three.\n\n- Four.\n\n- Five."
+        result = summary_bullets_to_html(text)
+        assert result.count("<li>") == 5
+        assert '<details class="summary-more">' in result
+        # Both overflow bullets must be inside <details>
+        first_details = result.index("<details")
+        last_details_close = result.rindex("</details>")
+        assert result.index("<li>Four.</li>") > first_details
+        assert result.index("<li>Five.</li>") > first_details
+        assert result.index("<li>Five.</li>") < last_details_close
+
 
 class TestParseTruncation:
     def test_drops_truncated_last_bullet(self):

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -239,6 +239,25 @@ class TestSummaryBulletsToHtml:
         assert "<script>" not in result
         assert "<strong>&lt;script&gt;" in result
 
+    def test_italic_markdown_converted_to_em(self):
+        text = "- This is *important* context."
+        result = summary_bullets_to_html(text)
+        assert "<em>important</em>" in result
+        assert "*important*" not in result
+
+    def test_inline_code_converted_to_code(self):
+        text = "- The `text_overlap` check failed."
+        result = summary_bullets_to_html(text)
+        assert "<code>text_overlap</code>" in result
+        assert "`text_overlap`" not in result
+
+    def test_mixed_inline_markdown(self):
+        text = "- **Bold** and *italic* and `code` together."
+        result = summary_bullets_to_html(text)
+        assert "<strong>Bold</strong>" in result
+        assert "<em>italic</em>" in result
+        assert "<code>code</code>" in result
+
     def test_three_or_fewer_bullets_no_collapse(self):
         text = "- First.\n- Second.\n- Third."
         result = summary_bullets_to_html(text)

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -422,6 +422,21 @@ class TestBuildSinglePayload:
         assert "text_overlap" not in payload
         assert "price_outlier" in payload
 
+    def test_duplicate_check_displayed_as_near_duplicate(self):
+        """The 'duplicate' check should appear as 'near_duplicate' in the payload."""
+        checks = [
+            CheckResult(
+                check_name="duplicate",
+                query="shoes",
+                product_id="SKU-1",
+                passed=False,
+                detail="Near-duplicate pair found",
+            ),
+        ]
+        payload = _build_single_payload(_make_metrics(), checks, None, None, None)
+        assert "near_duplicate" in payload
+        assert "- duplicate:" not in payload
+
     def test_includes_worst_queries(self):
         payload = _build_single_payload(
             _make_metrics(),

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -261,35 +261,38 @@ class TestSummaryBulletsToHtml:
     def test_three_or_fewer_bullets_no_collapse(self):
         text = "- First.\n- Second.\n- Third."
         result = summary_bullets_to_html(text)
-        assert "<details" not in result
+        assert "summary-overflow" not in result
+        assert "summary-toggle" not in result
         assert result.count("<li>") == 3
 
     def test_more_than_three_bullets_collapsed(self):
         text = "- One.\n- Two.\n- Three.\n- Four.\n- Five."
         result = summary_bullets_to_html(text)
         assert result.count("<li>") == 5
-        assert '<details class="summary-more">' in result
+        assert 'class="summary-overflow"' in result
         assert "Show more" in result
         # First 3 bullets in the visible <ul>
-        first_details = result.index("<details")
-        assert result.index("<li>One.</li>") < first_details
-        assert result.index("<li>Three.</li>") < first_details
-        # Bullets 4-5 inside <details>
-        assert result.index("<li>Four.</li>") > first_details
-        assert result.index("<li>Five.</li>") > first_details
+        overflow_start = result.index("summary-overflow")
+        assert result.index("<li>One.</li>") < overflow_start
+        assert result.index("<li>Three.</li>") < overflow_start
+        # Bullets 4-5 inside the overflow div
+        assert result.index("<li>Four.</li>") > overflow_start
+        assert result.index("<li>Five.</li>") > overflow_start
+        # Button is after the overflow div
+        assert '<button class="summary-toggle"' in result
 
     def test_blank_lines_between_bullets_stay_collapsed(self):
         """LLMs typically separate bullets with blank lines."""
         text = "- One.\n\n- Two.\n\n- Three.\n\n- Four.\n\n- Five."
         result = summary_bullets_to_html(text)
         assert result.count("<li>") == 5
-        assert '<details class="summary-more">' in result
-        # Both overflow bullets must be inside <details>
-        first_details = result.index("<details")
-        last_details_close = result.rindex("</details>")
-        assert result.index("<li>Four.</li>") > first_details
-        assert result.index("<li>Five.</li>") > first_details
-        assert result.index("<li>Five.</li>") < last_details_close
+        assert 'class="summary-overflow"' in result
+        # Both overflow bullets must be inside the overflow div
+        overflow_start = result.index("summary-overflow")
+        last_div_close = result.rindex("</div>")
+        assert result.index("<li>Four.</li>") > overflow_start
+        assert result.index("<li>Five.</li>") > overflow_start
+        assert result.index("<li>Five.</li>") < last_div_close
 
 
 class TestParseTruncation:

--- a/tests/test_reporting/test_summary.py
+++ b/tests/test_reporting/test_summary.py
@@ -64,11 +64,11 @@ def _make_checks() -> list[CheckResult]:
             detail="OK",
         ),
         CheckResult(
-            check_name="text_overlap",
+            check_name="oos_prominence",
             query="laptop",
             product_id="SKU-1",
             passed=False,
-            detail="Low keyword overlap: 10%",
+            detail="Out-of-stock product appears in top 5 (position 1)",
         ),
         CheckResult(
             check_name="price_outlier",
@@ -361,7 +361,65 @@ class TestBuildSinglePayload:
             None,
         )
         assert "Check Summary" in payload
-        assert "text_overlap" in payload
+        assert "oos_prominence" in payload
+        assert "price_outlier" in payload
+
+    def test_detection_only_checks_use_findings_label(self):
+        """Checks with 0 passes should say 'N findings' not '0 passed, N failed'."""
+        checks = [
+            CheckResult(
+                check_name="near_duplicate",
+                query="shoes",
+                product_id="SKU-1",
+                passed=False,
+                detail="Near-duplicate pair",
+            ),
+            CheckResult(
+                check_name="near_duplicate",
+                query="shoes",
+                product_id="SKU-2",
+                passed=False,
+                detail="Near-duplicate pair",
+            ),
+            CheckResult(
+                check_name="price_outlier",
+                query="shoes",
+                product_id="SKU-1",
+                passed=True,
+                detail="OK",
+            ),
+            CheckResult(
+                check_name="price_outlier",
+                query="shoes",
+                product_id="SKU-2",
+                passed=False,
+                detail="Outlier price",
+            ),
+        ]
+        payload = _build_single_payload(_make_metrics(), checks, None, None, None)
+        assert "near_duplicate: 2 findings" in payload
+        assert "price_outlier: 1 passed, 1 failed (50% fail rate)" in payload
+
+    def test_text_overlap_excluded_from_payload(self):
+        """text_overlap is redundant with judge scores and should be filtered."""
+        checks = [
+            CheckResult(
+                check_name="text_overlap",
+                query="shoes",
+                product_id="SKU-1",
+                passed=False,
+                detail="Low keyword overlap: 10%",
+            ),
+            CheckResult(
+                check_name="price_outlier",
+                query="shoes",
+                product_id="SKU-1",
+                passed=False,
+                detail="Outlier price",
+            ),
+        ]
+        payload = _build_single_payload(_make_metrics(), checks, None, None, None)
+        assert "text_overlap" not in payload
         assert "price_outlier" in payload
 
     def test_includes_worst_queries(self):
@@ -406,7 +464,7 @@ class TestBuildSinglePayload:
             None,
         )
         assert "Check Failure Samples" in payload
-        assert "Low keyword overlap" in payload
+        assert "Out-of-stock product" in payload
 
     def test_includes_corrections(self):
         payload = _build_single_payload(
@@ -464,11 +522,11 @@ class TestBuildSinglePayload:
         ]
         checks = [
             CheckResult(
-                check_name="text_overlap",
+                check_name="price_outlier",
                 query="shoes",
                 product_id="SKU-1",
                 passed=False,
-                detail="Low overlap",
+                detail="Outlier price",
             ),
         ]
         payload = _build_single_payload(metrics, checks, judgments, None, None)
@@ -479,7 +537,7 @@ class TestBuildSinglePayload:
         # Raw-query lookup should find score data
         assert "pos1=" in payload
         # Raw-query lookup should find failed checks
-        assert "text_overlap" in payload
+        assert "price_outlier" in payload
 
     def test_no_judgments_skips_judgment_sections(self):
         payload = _build_single_payload(
@@ -555,7 +613,7 @@ class TestBuildComparisonPayload:
     def test_includes_check_deltas(self):
         checks_a = [
             CheckResult(
-                check_name="text_overlap",
+                check_name="price_outlier",
                 query="q1",
                 product_id="p1",
                 passed=False,
@@ -564,7 +622,7 @@ class TestBuildComparisonPayload:
         ]
         checks_b = [
             CheckResult(
-                check_name="text_overlap",
+                check_name="price_outlier",
                 query="q1",
                 product_id="p1",
                 passed=True,
@@ -585,6 +643,40 @@ class TestBuildComparisonPayload:
             None,
         )
         assert "Check Failure Deltas" in payload
+
+    def test_text_overlap_excluded_from_comparison_payload(self):
+        """text_overlap should be filtered from comparison payloads too."""
+        checks_a = [
+            CheckResult(
+                check_name="text_overlap",
+                query="q1",
+                product_id="p1",
+                passed=False,
+                detail="Low overlap",
+            ),
+            CheckResult(
+                check_name="price_outlier",
+                query="q1",
+                product_id="p1",
+                passed=False,
+                detail="Outlier",
+            ),
+        ]
+        payload = _build_comparison_payload(
+            _make_metrics(),
+            _make_metrics(),
+            checks_a,
+            None,
+            None,
+            None,
+            [],
+            "A",
+            "B",
+            None,
+            None,
+        )
+        assert "text_overlap" not in payload
+        assert "price_outlier" in payload
 
     def test_includes_query_type_metrics(self):
         payload = _build_comparison_payload(


### PR DESCRIPTION
## Summary

- Adds an **AI Summary** section to both single-config and A/B comparison HTML reports (and terminal output) by making one additional LLM call after evaluation
- Surfaces non-obvious patterns and actionable insights by cross-referencing metrics, check failures, judgment scores, query-type breakdowns, and worst-query examples
- Gracefully omits itself when nothing meaningful is found (`__NO_INSIGHTS__` sentinel) or on any error
- New `--no-summary` CLI flag to disable the feature entirely

### New files
- `src/veritail/reporting/summary.py` — payload builders, LLM calling, response parsing, HTML bullet conversion
- `src/veritail/prompts/reporting/summary.md` — single-report system prompt
- `src/veritail/prompts/reporting/comparison_summary.md` — A/B comparison system prompt
- `tests/test_reporting/test_summary.py` — 52 tests

### Modified files
- `cli.py` — `--no-summary` flag, summary generation in single/dual paths (wrapped in try/except)
- `single.py`, `comparison.py` — `summary` param plumbing to terminal (Rich Panel) + HTML (template context)
- `report.html` — conditional summary card + nav link in both report types
- `styles.py` — `.summary-card`, `.summary-badge`, `.summary-content` CSS

## Review fixes

All 4 findings from PR review addressed:

| Commit | Finding | Severity | Fix |
|--------|---------|----------|-----|
| `4bf1b53` | Error handling contract | Low | `generate_summary()` / `generate_comparison_summary()` now catch exceptions internally and return `None`, matching docstrings |
| `1e1d8eb` | High-variance label misleading | Medium | Renamed to "Mixed-Relevance Queries (widest score spread)" — healthy `[3,2,1,0]` decay is not inconsistency |
| `ba17d73` | Duplicate query key mismatch | Medium | Added `_strip_disambiguation()` to resolve `"shoes [1]"` → `"shoes"` for lookups |
| `fc019a0` | Comparison payload missing data | High | Added result overlap (Jaccard), position shifts, per-config score distributions, and p-value significance to metric deltas |

## Test plan

- [x] 52 unit tests covering payload builders, response parser, HTML converter, generate functions with mock client, and full report integration
- [x] Full test suite: 2193 passed, 0 failed
- [x] mypy: 58 source files, no issues
- [x] ruff: all checks passed
- [x] Manual test with live API key to verify summary appears in HTML and terminal output

🤖 Generated with [Claude Code](https://claude.com/claude-code)